### PR TITLE
fix: update documentation links in product descriptions

### DIFF
--- a/src/takrmapi/api/description.py
+++ b/src/takrmapi/api/description.py
@@ -90,7 +90,7 @@ async def return_product_description_extended(language: str) -> ProductDescripti
             icon="/ui/tak/taklogo.svg",
             description="Tilannekuvajärjestelmä",
             language="fi",
-            docs="https://docs.pvarki.fi/",
+            docs="https://docs.pvarki.fi/fi/docs/guides/tak-guide",
             component=ProductComponent(type="component", ref="/ui/tak/remoteEntry.js"),
         )
     if language == "sv":
@@ -100,7 +100,7 @@ async def return_product_description_extended(language: str) -> ProductDescripti
             icon="/ui/tak/taklogo.svg",
             description="Situationsbildsystem",
             language="sv",
-            docs="https://docs.pvarki.fi/",
+            docs="https://docs.pvarki.fi/sv/docs/guides/tak-guide",
             component=ProductComponent(type="component", ref="/ui/tak/remoteEntry.js"),
         )
     # Fall back to English
@@ -110,7 +110,7 @@ async def return_product_description_extended(language: str) -> ProductDescripti
         icon="/ui/tak/taklogo.svg",
         description="Situational awareness system",
         language="en",
-        docs="https://docs.pvarki.fi/",
+        docs="https://docs.pvarki.fi/en/docs/guides/tak-guide",
         component=ProductComponent(type="component", ref="/ui/tak/remoteEntry.js"),
     )
 


### PR DESCRIPTION
## Summary

Updates the documentation links in `src/takrmapi/api/description.py` to point to language-specific guide pages instead of the generic docs root.

## Changes

Replaces `https://docs.pvarki.fi/` with the correct language-specific TAK guide URLs across all three language branches:

- `fi` → `https://docs.pvarki.fi/fi/docs/guides/tak-guide`
- `sv` → `https://docs.pvarki.fi/sv/docs/guides/tak-guide`
- `en` → `https://docs.pvarki.fi/en/docs/guides/tak-guide`

## Why

Users were being directed to the documentation root rather than the relevant TAK guide for their language, resulting in a poorer experience when following documentation links from the product UI.