### PR TITLE
fix: protect request time attribute

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.10.2
+current_version = 1.11.0
 commit = False
 tag = False
 

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+# Configuration related to self-hosted runner.
+self-hosted-runner:
+  # Labels of self-hosted runner in array of strings.
+  labels:
+    - arc-runner-set

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,14 +2,28 @@ on:
     pull_request:
 
 jobs:
-  test:
+  versiontag:
     runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v5
+      - name: Check version tag
+        run: |
+          curl -f https://raw.githubusercontent.com/pvarki/python-tak-rmapi/main/pyproject.toml -o /tmp/main_pyproject.toml || touch /tmp/main_pyproject.toml
+          grep "version = " pyproject.toml >/tmp/version.txt
+          grep "version = " /tmp/main_pyproject.toml >/tmp/main_version.txt
+          diff /tmp/main_version.txt /tmp/version.txt && exit 1 || exit 0
+
+  test:
+    runs-on: arc-runner-set
     permissions:
       contents: write
       pull-requests: write
       checks: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
       - name: Build test image
         run: |
           docker build --target test -t takrmapi:test .
@@ -24,10 +38,16 @@ jobs:
           detailed_summary: true
           check_name: 'JUnit report (local)'
 
-  devel_shell:
-    runs-on: ubuntu-latest
+  docker_builds:
+    runs-on: arc-runner-set
     steps:
-    - uses: pvarki/ci@main
-      with:
-        dockerfile-target: devel_shell
-        image-tag: takrmapi:devel_shell
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
+      - name: Build production target
+        run: docker build --target production -t takrmapi:production .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,3 +99,8 @@ repos:
           - "@typescript-eslint/eslint-plugin"
           - "eslint-plugin-react-hooks"
           - "eslint-plugin-react-refresh"
+-   repo: https://github.com/rhysd/actionlint
+    rev: "v1.7.8"
+    hooks:
+        - id: actionlint
+          args: ["-shellcheck", "''"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM ${TAKSERVER_IMAGE} as tak_server
 # Tox testsuite for multiple python version #
 #############################################
 FROM advian/tox-base:debian-bookworm as tox
-ARG PYTHON_VERSIONS="3.11 3.10 3.9 3.11"
+ARG PYTHON_VERSIONS="3.11 3.12 3.13 3.14"
 ARG POETRY_VERSION="2.2.1"
 RUN export RESOLVED_VERSIONS=`pyenv_resolve $PYTHON_VERSIONS` \
     && echo RESOLVED_VERSIONS=$RESOLVED_VERSIONS \
@@ -54,7 +54,7 @@ RUN apt-get update && apt-get install -y \
         tini \
         openssh-client \
         cargo \
-        python3.10 \
+        python3.11 \
         python3-pip \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/* \
@@ -130,7 +130,7 @@ RUN --mount=type=ssh apt-get update && apt-get install -y \
         openssh-client \
         curl \
         jq \
-        python3.10 \
+        python3.11 \
         python3-pip \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ RUN --mount=type=ssh \
     && poetry export -f requirements.txt --without-hashes -o /tmp/requirements.txt \
     && pip3 wheel --wheel-dir=/tmp/wheelhouse -r /tmp/requirements.txt \
     && virtualenv /.venv && source /.venv/bin/activate && echo 'source /.venv/bin/activate' >>/root/.profile \
-    && pip3 install --no-deps --find-links=/tmp/wheelhouse/ /tmp/wheelhouse/*.whl \
+    && pip3 install --break-system-packages --no-deps --find-links=/tmp/wheelhouse/ -r /tmp/requirements.txt \
     && true
 
 
@@ -137,7 +137,7 @@ RUN --mount=type=ssh apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/* \
     && chmod a+x /docker-entrypoint.sh \
     && WHEELFILE=`echo /tmp/wheelhouse/takrmap*.whl` \
-    && pip3 install --index-url https://nexus.dev.pvarki.fi/repository/python/simple --find-links=/tmp/wheelhouse/ "$WHEELFILE"[all] \
+    && pip3 install --break-system-packages --index-url https://nexus.dev.pvarki.fi/repository/python/simple --find-links=/tmp/wheelhouse/ "$WHEELFILE"[all] \
     && rm -rf /tmp/wheelhouse/ \
     # Make some directories
     && mkdir -p /opt/tak/data/certs \
@@ -191,7 +191,7 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y zsh \
     && sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" \
     && echo "source /root/.profile" >>/root/.zshrc \
-    && pip3 install git-up \
+    && pip3 --break-system-packages install git-up \
     && ln -s /app/docker/container-init.sh /container-init.sh \
     && curl https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh -o /usr/bin/wait-for-it.sh \
     && chmod a+x /usr/bin/wait-for-it.sh \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN export RESOLVED_VERSIONS=`pyenv_resolve $PYTHON_VERSIONS` \
 ######################
 # Base builder image #
 ######################
-FROM eclipse-temurin:${TEMURIN_VERSION}-jammy as builder_base
+FROM eclipse-temurin:${TEMURIN_VERSION}-noble as builder_base
 #FROM python:3.11-bookworm as builder_base
 ENV \
   # locale
@@ -54,8 +54,9 @@ RUN apt-get update && apt-get install -y \
         tini \
         openssh-client \
         cargo \
-        python3.11 \
+        python3 \
         python3-pip \
+        python3-virtualenv  \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/* \
     # githublab ssh
@@ -74,8 +75,8 @@ SHELL ["/bin/bash", "-lc"]
 WORKDIR /pysetup
 COPY ./poetry.lock ./pyproject.toml /pysetup/
 # Install basic requirements (utilizing an internal docker wheelhouse if available)
-RUN --mount=type=ssh pip3 install wheel virtualenv \
-    && poetry self add poetry-plugin-pypi-mirror \
+RUN --mount=type=ssh \
+    poetry self add poetry-plugin-pypi-mirror \
     && poetry self add poetry-plugin-export \
     && poetry export -f requirements.txt --without-hashes -o /tmp/requirements.txt \
     && pip3 wheel --wheel-dir=/tmp/wheelhouse -r /tmp/requirements.txt \
@@ -108,7 +109,7 @@ RUN --mount=type=ssh source /.venv/bin/activate \
 #########################
 # Main production build #
 #########################
-FROM eclipse-temurin:${TEMURIN_VERSION}-jammy as production
+FROM eclipse-temurin:${TEMURIN_VERSION}-noble as production
 COPY --from=production_build /tmp/wheelhouse /tmp/wheelhouse
 COPY --from=production_build /ui_build /ui_build
 COPY --from=production_build /docker-entrypoint.sh /docker-entrypoint.sh
@@ -130,7 +131,7 @@ RUN --mount=type=ssh apt-get update && apt-get install -y \
         openssh-client \
         curl \
         jq \
-        python3.11 \
+        python3 \
         python3-pip \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.1.7-experimental
 ARG TEMURIN_VERSION="17"
-ARG TAKSERVER_IMAGE="pvarki/takserver:5.3-RELEASE-24"
+ARG TAKSERVER_IMAGE="pvarki/takserver:5.7-RELEASE-8"
 
 # The local reference tak_server is used in future stages
 FROM ${TAKSERVER_IMAGE} as tak_server

--- a/poetry.lock
+++ b/poetry.lock
@@ -160,7 +160,6 @@ files = [
 [package.dependencies]
 aiohappyeyeballs = ">=2.5.0"
 aiosignal = ">=1.4.0"
-async-timeout = {version = ">=4.0,<6.0", markers = "python_version < \"3.11\""}
 attrs = ">=17.3.0"
 frozenlist = ">=1.1.1"
 multidict = ">=4.5,<7.0"
@@ -223,7 +222,6 @@ files = [
 ]
 
 [package.dependencies]
-exceptiongroup = {version = ">=1.0.2", markers = "python_version < \"3.11\""}
 idna = ">=2.8"
 typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
 
@@ -240,22 +238,6 @@ groups = ["dev"]
 files = [
     {file = "astroid-3.3.11-py3-none-any.whl", hash = "sha256:54c760ae8322ece1abd213057c4b5bba7c49818853fc901ef09719a60dbf9dec"},
     {file = "astroid-3.3.11.tar.gz", hash = "sha256:1e5a5011af2920c7c67a53f65d536d65bfa7116feeaf2354d8b94f29573bb0ce"},
-]
-
-[package.dependencies]
-typing-extensions = {version = ">=4", markers = "python_version < \"3.11\""}
-
-[[package]]
-name = "async-timeout"
-version = "5.0.1"
-description = "Timeout context manager for asyncio programs"
-optional = false
-python-versions = ">=3.8"
-groups = ["main"]
-markers = "python_version == \"3.10\""
-files = [
-    {file = "async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c"},
-    {file = "async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3"},
 ]
 
 [[package]]
@@ -339,8 +321,6 @@ packaging = ">=22.0"
 pathspec = ">=0.9.0"
 platformdirs = ">=2"
 pytokens = ">=0.3.0"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typing-extensions = {version = ">=4.0.1", markers = "python_version < \"3.11\""}
 
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
@@ -468,46 +448,6 @@ groups = ["dev"]
 files = [
     {file = "bump2version-1.0.1-py2.py3-none-any.whl", hash = "sha256:37f927ea17cde7ae2d7baf832f8e80ce3777624554a653006c9144f8017fe410"},
     {file = "bump2version-1.0.1.tar.gz", hash = "sha256:762cb2bfad61f4ec8e2bdf452c7c267416f8c70dd9ecb1653fd0bbb01fa936e6"},
-]
-
-[[package]]
-name = "cchardet"
-version = "2.1.7"
-description = "cChardet is high speed universal character encoding detector."
-optional = false
-python-versions = "*"
-groups = ["main"]
-markers = "python_full_version == \"3.10.0\""
-files = [
-    {file = "cchardet-2.1.7-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:c6f70139aaf47ffb94d89db603af849b82efdf756f187cdd3e566e30976c519f"},
-    {file = "cchardet-2.1.7-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:5a25f9577e9bebe1a085eec2d6fdd72b7a9dd680811bba652ea6090fb2ff472f"},
-    {file = "cchardet-2.1.7-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:6b6397d8a32b976a333bdae060febd39ad5479817fabf489e5596a588ad05133"},
-    {file = "cchardet-2.1.7-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:228d2533987c450f39acf7548f474dd6814c446e9d6bd228e8f1d9a2d210f10b"},
-    {file = "cchardet-2.1.7-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:54341e7e1ba9dc0add4c9d23b48d3a94e2733065c13920e85895f944596f6150"},
-    {file = "cchardet-2.1.7-cp36-cp36m-win32.whl", hash = "sha256:eee4f5403dc3a37a1ca9ab87db32b48dc7e190ef84601068f45397144427cc5e"},
-    {file = "cchardet-2.1.7-cp36-cp36m-win_amd64.whl", hash = "sha256:f86e0566cb61dc4397297696a4a1b30f6391b50bc52b4f073507a48466b6255a"},
-    {file = "cchardet-2.1.7-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:302aa443ae2526755d412c9631136bdcd1374acd08e34f527447f06f3c2ddb98"},
-    {file = "cchardet-2.1.7-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:70eeae8aaf61192e9b247cf28969faef00578becd2602526ecd8ae7600d25e0e"},
-    {file = "cchardet-2.1.7-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:a39526c1c526843965cec589a6f6b7c2ab07e3e56dc09a7f77a2be6a6afa4636"},
-    {file = "cchardet-2.1.7-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:b154effa12886e9c18555dfc41a110f601f08d69a71809c8d908be4b1ab7314f"},
-    {file = "cchardet-2.1.7-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:ec3eb5a9c475208cf52423524dcaf713c394393e18902e861f983c38eeb77f18"},
-    {file = "cchardet-2.1.7-cp37-cp37m-win32.whl", hash = "sha256:50ad671e8d6c886496db62c3bd68b8d55060688c655873aa4ce25ca6105409a1"},
-    {file = "cchardet-2.1.7-cp37-cp37m-win_amd64.whl", hash = "sha256:54d0b26fd0cd4099f08fb9c167600f3e83619abefeaa68ad823cc8ac1f7bcc0c"},
-    {file = "cchardet-2.1.7-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b59ddc615883835e03c26f81d5fc3671fab2d32035c87f50862de0da7d7db535"},
-    {file = "cchardet-2.1.7-cp38-cp38-manylinux1_i686.whl", hash = "sha256:27a9ba87c9f99e0618e1d3081189b1217a7d110e5c5597b0b7b7c3fedd1c340a"},
-    {file = "cchardet-2.1.7-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:90086e5645f8a1801350f4cc6cb5d5bf12d3fa943811bb08667744ec1ecc9ccd"},
-    {file = "cchardet-2.1.7-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:45456c59ec349b29628a3c6bfb86d818ec3a6fbb7eb72de4ff3bd4713681c0e3"},
-    {file = "cchardet-2.1.7-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:f16517f3697569822c6d09671217fdeab61dfebc7acb5068634d6b0728b86c0b"},
-    {file = "cchardet-2.1.7-cp38-cp38-win32.whl", hash = "sha256:0b859069bbb9d27c78a2c9eb997e6f4b738db2d7039a03f8792b4058d61d1109"},
-    {file = "cchardet-2.1.7-cp38-cp38-win_amd64.whl", hash = "sha256:273699c4e5cd75377776501b72a7b291a988c6eec259c29505094553ee505597"},
-    {file = "cchardet-2.1.7-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:48ba829badef61441e08805cfa474ccd2774be2ff44b34898f5854168c596d4d"},
-    {file = "cchardet-2.1.7-cp39-cp39-manylinux1_i686.whl", hash = "sha256:bd7f262f41fd9caf5a5f09207a55861a67af6ad5c66612043ed0f81c58cdf376"},
-    {file = "cchardet-2.1.7-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:fdac1e4366d0579fff056d1280b8dc6348be964fda8ebb627c0269e097ab37fa"},
-    {file = "cchardet-2.1.7-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:80e6faae75ecb9be04a7b258dc4750d459529debb6b8dee024745b7b5a949a34"},
-    {file = "cchardet-2.1.7-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:c96aee9ebd1147400e608a3eff97c44f49811f8904e5a43069d55603ac4d8c97"},
-    {file = "cchardet-2.1.7-cp39-cp39-win32.whl", hash = "sha256:2309ff8fc652b0fc3c0cff5dbb172530c7abb92fe9ba2417c9c0bcf688463c1c"},
-    {file = "cchardet-2.1.7-cp39-cp39-win_amd64.whl", hash = "sha256:24974b3e40fee9e7557bb352be625c39ec6f50bc2053f44a3d1191db70b51675"},
-    {file = "cchardet-2.1.7.tar.gz", hash = "sha256:c428b6336545053c2589f6caf24ea32276c6664cb86db817e03a94c60afa0eaf"},
 ]
 
 [[package]]
@@ -885,9 +825,6 @@ files = [
     {file = "coverage-7.13.0.tar.gz", hash = "sha256:a394aa27f2d7ff9bc04cf703817773a59ad6dfbd577032e690f961d2460ee936"},
 ]
 
-[package.dependencies]
-tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.11.0a6\" and extra == \"toml\""}
-
 [package.extras]
 toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
@@ -957,7 +894,6 @@ files = [
 
 [package.dependencies]
 cffi = {version = ">=2.0.0", markers = "python_full_version >= \"3.9.0\" and platform_python_implementation != \"PyPy\""}
-typing-extensions = {version = ">=4.13.2", markers = "python_full_version < \"3.11.0\""}
 
 [package.extras]
 docs = ["sphinx (>=5.3.0)", "sphinx-inline-tabs", "sphinx-rtd-theme (>=3.0.0)"]
@@ -1031,25 +967,6 @@ files = [
 
 [package.extras]
 develop = ["elastic-apm", "mock", "pytest", "pytest-cov", "structlog"]
-
-[[package]]
-name = "exceptiongroup"
-version = "1.3.1"
-description = "Backport of PEP 654 (exception groups)"
-optional = false
-python-versions = ">=3.7"
-groups = ["main", "dev"]
-markers = "python_version == \"3.10\""
-files = [
-    {file = "exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598"},
-    {file = "exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219"},
-]
-
-[package.dependencies]
-typing-extensions = {version = ">=4.6.0", markers = "python_version < \"3.13\""}
-
-[package.extras]
-test = ["pytest (>=6)"]
 
 [[package]]
 name = "fastapi"
@@ -1456,29 +1373,29 @@ vector = ["http"]
 
 [[package]]
 name = "libpvarki"
-version = "2.1.0"
+version = "2.2.0"
 description = "Common helpers like standard logging init"
 optional = false
-python-versions = ">3.9.1,<4.0"
+python-versions = ">3.10,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "libpvarki-2.2.0-py3-none-any.whl", hash = "sha256:ce6ddeca0079b21ce85d0b6974781af102aca559f7c6c7e2f3a7335073e7fbb2"},
+    {file = "libpvarki-2.2.0.tar.gz", hash = "sha256:202d8a33991147e56b0ac46d3290dd24e1cd028842bf519f7cdecf524c047242"},
+]
 
 [package.dependencies]
-aiodns = "^3.0"
+aiodns = ">=3.0,<4.0"
 aiohttp = ">=3.10.2,<4.0"
-brotli = "^1.0"
-cchardet = {version = "^2.1", markers = "python_full_version <= \"3.10.0\""}
+brotli = ">=1.0,<2.0"
 cryptography = ">=44.0.1"
-ecs-logging = "^2.0"
+ecs-logging = ">=2.0,<3.0"
 fastapi = ">0.89,<1.0"
 pydantic = ">=2.0,<3.0"
 
 [package.source]
-type = "git"
-url = "https://github.com/pvarki/python-libpvarki.git"
-reference = "2.1.0"
-resolved_reference = "197189cc1e428e8c58a1a266f21e06a9094fd721"
+type = "legacy"
+url = "https://nexus.dev.pvarki.fi/repository/pypilocal/simple"
+reference = "nexuslocal"
 
 [[package]]
 name = "librt"
@@ -1869,9 +1786,6 @@ files = [
     {file = "multidict-6.7.0.tar.gz", hash = "sha256:c6e99d9a65ca282e578dfea819cfa9c0a62b2499d8677392e09feaf305e9e6f5"},
 ]
 
-[package.dependencies]
-typing-extensions = {version = ">=4.1.0", markers = "python_version < \"3.11\""}
-
 [[package]]
 name = "mypy"
 version = "1.19.0"
@@ -1924,7 +1838,6 @@ files = [
 librt = ">=0.6.2"
 mypy_extensions = ">=1.0.0"
 pathspec = ">=0.9.0"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
 typing_extensions = ">=4.6.0"
 
 [package.extras]
@@ -2477,14 +2390,12 @@ files = [
 astroid = ">=3.3.8,<=3.4.0.dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 dill = [
-    {version = ">=0.2", markers = "python_version < \"3.11\""},
     {version = ">=0.3.7", markers = "python_version >= \"3.12\""},
     {version = ">=0.3.6", markers = "python_version == \"3.11\""},
 ]
 isort = ">=4.2.5,<5.13 || >5.13,<7"
 mccabe = ">=0.6,<0.8"
 platformdirs = ">=2.2"
-tomli = {version = ">=1.1", markers = "python_version < \"3.11\""}
 tomlkit = ">=0.10.1"
 
 [package.extras]
@@ -2525,12 +2436,10 @@ files = [
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
-exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
 iniconfig = ">=1"
 packaging = ">=20"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
-tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 
 [package.extras]
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
@@ -2759,59 +2668,6 @@ files = [
 ]
 
 [[package]]
-name = "tomli"
-version = "2.3.0"
-description = "A lil' TOML parser"
-optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
-markers = "python_version == \"3.10\""
-files = [
-    {file = "tomli-2.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:88bd15eb972f3664f5ed4b57c1634a97153b4bac4479dcb6a495f41921eb7f45"},
-    {file = "tomli-2.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:883b1c0d6398a6a9d29b508c331fa56adbcdff647f6ace4dfca0f50e90dfd0ba"},
-    {file = "tomli-2.3.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d1381caf13ab9f300e30dd8feadb3de072aeb86f1d34a8569453ff32a7dea4bf"},
-    {file = "tomli-2.3.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a0e285d2649b78c0d9027570d4da3425bdb49830a6156121360b3f8511ea3441"},
-    {file = "tomli-2.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0a154a9ae14bfcf5d8917a59b51ffd5a3ac1fd149b71b47a3a104ca4edcfa845"},
-    {file = "tomli-2.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:74bf8464ff93e413514fefd2be591c3b0b23231a77f901db1eb30d6f712fc42c"},
-    {file = "tomli-2.3.0-cp311-cp311-win32.whl", hash = "sha256:00b5f5d95bbfc7d12f91ad8c593a1659b6387b43f054104cda404be6bda62456"},
-    {file = "tomli-2.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:4dc4ce8483a5d429ab602f111a93a6ab1ed425eae3122032db7e9acf449451be"},
-    {file = "tomli-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d7d86942e56ded512a594786a5ba0a5e521d02529b3826e7761a05138341a2ac"},
-    {file = "tomli-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:73ee0b47d4dad1c5e996e3cd33b8a76a50167ae5f96a2607cbe8cc773506ab22"},
-    {file = "tomli-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:792262b94d5d0a466afb5bc63c7daa9d75520110971ee269152083270998316f"},
-    {file = "tomli-2.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4f195fe57ecceac95a66a75ac24d9d5fbc98ef0962e09b2eddec5d39375aae52"},
-    {file = "tomli-2.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e31d432427dcbf4d86958c184b9bfd1e96b5b71f8eb17e6d02531f434fd335b8"},
-    {file = "tomli-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7b0882799624980785240ab732537fcfc372601015c00f7fc367c55308c186f6"},
-    {file = "tomli-2.3.0-cp312-cp312-win32.whl", hash = "sha256:ff72b71b5d10d22ecb084d345fc26f42b5143c5533db5e2eaba7d2d335358876"},
-    {file = "tomli-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:1cb4ed918939151a03f33d4242ccd0aa5f11b3547d0cf30f7c74a408a5b99878"},
-    {file = "tomli-2.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5192f562738228945d7b13d4930baffda67b69425a7f0da96d360b0a3888136b"},
-    {file = "tomli-2.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:be71c93a63d738597996be9528f4abe628d1adf5e6eb11607bc8fe1a510b5dae"},
-    {file = "tomli-2.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c4665508bcbac83a31ff8ab08f424b665200c0e1e645d2bd9ab3d3e557b6185b"},
-    {file = "tomli-2.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4021923f97266babc6ccab9f5068642a0095faa0a51a246a6a02fccbb3514eaf"},
-    {file = "tomli-2.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4ea38c40145a357d513bffad0ed869f13c1773716cf71ccaa83b0fa0cc4e42f"},
-    {file = "tomli-2.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ad805ea85eda330dbad64c7ea7a4556259665bdf9d2672f5dccc740eb9d3ca05"},
-    {file = "tomli-2.3.0-cp313-cp313-win32.whl", hash = "sha256:97d5eec30149fd3294270e889b4234023f2c69747e555a27bd708828353ab606"},
-    {file = "tomli-2.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:0c95ca56fbe89e065c6ead5b593ee64b84a26fca063b5d71a1122bf26e533999"},
-    {file = "tomli-2.3.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:cebc6fe843e0733ee827a282aca4999b596241195f43b4cc371d64fc6639da9e"},
-    {file = "tomli-2.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4c2ef0244c75aba9355561272009d934953817c49f47d768070c3c94355c2aa3"},
-    {file = "tomli-2.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c22a8bf253bacc0cf11f35ad9808b6cb75ada2631c2d97c971122583b129afbc"},
-    {file = "tomli-2.3.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0eea8cc5c5e9f89c9b90c4896a8deefc74f518db5927d0e0e8d4a80953d774d0"},
-    {file = "tomli-2.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b74a0e59ec5d15127acdabd75ea17726ac4c5178ae51b85bfe39c4f8a278e879"},
-    {file = "tomli-2.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b5870b50c9db823c595983571d1296a6ff3e1b88f734a4c8f6fc6188397de005"},
-    {file = "tomli-2.3.0-cp314-cp314-win32.whl", hash = "sha256:feb0dacc61170ed7ab602d3d972a58f14ee3ee60494292d384649a3dc38ef463"},
-    {file = "tomli-2.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:b273fcbd7fc64dc3600c098e39136522650c49bca95df2d11cf3b626422392c8"},
-    {file = "tomli-2.3.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:940d56ee0410fa17ee1f12b817b37a4d4e4dc4d27340863cc67236c74f582e77"},
-    {file = "tomli-2.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f85209946d1fe94416debbb88d00eb92ce9cd5266775424ff81bc959e001acaf"},
-    {file = "tomli-2.3.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a56212bdcce682e56b0aaf79e869ba5d15a6163f88d5451cbde388d48b13f530"},
-    {file = "tomli-2.3.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c5f3ffd1e098dfc032d4d3af5c0ac64f6d286d98bc148698356847b80fa4de1b"},
-    {file = "tomli-2.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5e01decd096b1530d97d5d85cb4dff4af2d8347bd35686654a004f8dea20fc67"},
-    {file = "tomli-2.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8a35dd0e643bb2610f156cca8db95d213a90015c11fee76c946aa62b7ae7e02f"},
-    {file = "tomli-2.3.0-cp314-cp314t-win32.whl", hash = "sha256:a1f7f282fe248311650081faafa5f4732bdbfef5d45fe3f2e702fbc6f2d496e0"},
-    {file = "tomli-2.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:70a251f8d4ba2d9ac2542eecf008b3c8a9fc5c3f9f02c56a9d7952612be2fdba"},
-    {file = "tomli-2.3.0-py3-none-any.whl", hash = "sha256:e95b1af3c5b07d9e643909b5abbec77cd9f1217e6d0bca72b0234736b9fb1f1b"},
-    {file = "tomli-2.3.0.tar.gz", hash = "sha256:64be704a875d2a59753d80ee8a533c3fe183e3f06807ff7dc2232938ccb01549"},
-]
-
-[[package]]
 name = "tomlkit"
 version = "0.13.3"
 description = "Style preserving TOML library"
@@ -2902,7 +2758,6 @@ h11 = ">=0.8"
 httptools = {version = ">=0.6.3", optional = true, markers = "extra == \"standard\""}
 python-dotenv = {version = ">=0.13", optional = true, markers = "extra == \"standard\""}
 pyyaml = {version = ">=5.1", optional = true, markers = "extra == \"standard\""}
-typing-extensions = {version = ">=4.0", markers = "python_version < \"3.11\""}
 uvloop = {version = ">=0.15.1", optional = true, markers = "sys_platform != \"win32\" and sys_platform != \"cygwin\" and platform_python_implementation != \"PyPy\" and extra == \"standard\""}
 watchfiles = {version = ">=0.13", optional = true, markers = "extra == \"standard\""}
 websockets = {version = ">=10.4", optional = true, markers = "extra == \"standard\""}
@@ -2991,7 +2846,6 @@ files = [
 distlib = ">=0.3.7,<1"
 filelock = ">=3.12.2,<4"
 platformdirs = ">=3.9.1,<5"
-typing-extensions = {version = ">=4.13.2", markers = "python_version < \"3.11\""}
 
 [package.extras]
 docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2,!=7.3)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=23.6)"]
@@ -3436,5 +3290,5 @@ propcache = ">=0.2.1"
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.10,<4.0"
-content-hash = "acef254a801cec34fbcf2c07d7a099d9b69ef5064f5ffd6e57e5f1135b9135e3"
+python-versions = "^3.11"
+content-hash = "699957d0a2df7b90f2b63c917d1e6187cb423620fd0f0d2b06d1d8ac52ea444a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "takrmapi"
-version = "1.10.2"
+version = "1.11.0"
 description = "RASENMAEHER integration API for TAK server"
 authors = ["Eero af Heurlin <rambo@iki.fi>", "Ari Karhunen <FIXME@example.com>"]
 homepage = "https://github.com/pvarki/python-tak-rmapi"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,10 +59,15 @@ ignore-imports = true
 omit = ["tests/*"]
 branch = true
 
+[[tool.poetry.source]]
+name = "nexuslocal"
+url = "https://nexus.dev.pvarki.fi/repository/pypilocal/simple"
+priority = "explicit"
+
 [tool.poetry.dependencies]
-python = ">=3.10,<4.0"
+python = "^3.11"
 libadvian = "^1.4"
-libpvarki = { git="https://github.com/pvarki/python-libpvarki.git", tag="2.1.0" }
+libpvarki = { version="^2.2", source="nexuslocal"}
 fastapi = ">=0.89,<1.0,!=0.99.0"  # caret behaviour on 0.x is to lock to 0.x.*
 jinja2 = "^3.1"
 uvicorn = {version = ">=0.30,<1.0", extras = ["standard"]}

--- a/src/takrmapi/__init__.py
+++ b/src/takrmapi/__init__.py
@@ -1,3 +1,3 @@
 """RASENMAEHER integration API for TAK server"""
 
-__version__ = "1.10.2"  # NOTE Use `bump2version --config-file patch` to bump versions correctly
+__version__ = "1.11.0"  # NOTE Use `bump2version --config-file patch` to bump versions correctly

--- a/src/takrmapi/api/tak_missionpackage.py
+++ b/src/takrmapi/api/tak_missionpackage.py
@@ -192,7 +192,7 @@ def parse_encrypted_ephemeral_url_fragment(ephemeral_str: str) -> tuple[str, str
     user_uuid = decrypted_json["uuid"]
     link_generation_time = decrypted_json["request_time"]
     if link_generation_time + 300 < int(time.time()):
-        LOGGER.info("Ephemeral link has expired.")
+        LOGGER.audit("Ephemeral link has expired.")  # type: ignore[attr-defined]
         raise HTTPException(status_code=404, detail="User data not found")
 
     LOGGER.debug("Got the following data in ephemeral user payload: {}".format(decrypted_json))

--- a/src/takrmapi/api/tak_missionpackage.py
+++ b/src/takrmapi/api/tak_missionpackage.py
@@ -9,7 +9,7 @@ import time
 import os
 import json
 import secrets
-from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives import hashes, hmac
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 from fastapi import APIRouter, Depends, HTTPException, BackgroundTasks
@@ -28,17 +28,13 @@ router = APIRouter(dependencies=[Depends(MTLSHeader(auto_error=True))])
 ephemeral_router = APIRouter()
 
 
-def hash_from_str(hash_from: str) -> str:
+def hash_from_str(hash_from: str, hmac_key: bytes) -> str:
     """Return checksum string from given string"""
-    ct_digest = hashes.Hash(hashes.SHA256())
+    # ct_digest = hashes.Hash(hashes.SHA256())
+    ct_digest = hmac.HMAC(hmac_key, hashes.SHA256())
     ct_digest.update(hash_from.encode("ascii"))
     ct_dig = ct_digest.finalize()
-    try:
-        ct_dig_str = binascii.hexlify(ct_dig).decode()
-    except binascii.Error as e:
-        LOGGER.info("Unable to convert digest bin to string. Possible malformed query.")
-        LOGGER.debug(e)
-        return "err"
+    ct_dig_str = binascii.hexlify(ct_dig).decode()
 
     return ct_dig_str
 
@@ -132,19 +128,20 @@ def generate_encrypted_ephemeral_url_fragment(
     user_callsign: str, user_uuid: str, variant: str, request_time: float
 ) -> str:
     """Return encrypted ephemeral url"""
-    plaintext_str: str = json.dumps({"callsign": user_callsign, "uuid": user_uuid, "variant": variant})
+    plaintext_str: str = json.dumps(
+        {"callsign": user_callsign, "uuid": user_uuid, "variant": variant, "request_time": request_time}
+    )
     iv = os.urandom(12)
-    encryptor = Cipher(algorithms.AES(TAKDataPackage.get_ephemeral_byteskey()), modes.GCM(iv)).encryptor()
+    encryptor = Cipher(algorithms.AES(TAKDataPackage.get_ephemeral_aes_key()), modes.GCM(iv)).encryptor()
     user_payload: bytes = encryptor.update(plaintext_str.encode("ascii")) + encryptor.finalize()
     user_payload_b64: str = base64.b64encode(user_payload).decode("ascii")
     iv_b64: str = base64.b64encode(iv).decode("ascii")
-    payload_digest: str = hash_from_str(user_payload_b64 + iv_b64 + str(request_time))
+    payload_digest: str = hash_from_str(user_payload_b64 + iv_b64, TAKDataPackage.get_ephemeral_hmac_key())
     encode: str = base64.b64encode(
         json.dumps(
             {
                 "payload_b64": user_payload_b64,
                 "iv_b64": iv_b64,
-                "request_time": request_time,
                 "digest": payload_digest,
             }
         ).encode("ascii")
@@ -166,13 +163,9 @@ def parse_encrypted_ephemeral_url_fragment(ephemeral_str: str) -> tuple[str, str
         raise HTTPException(status_code=404, detail="User data not found") from exc
 
     ephemeral_json = json.loads(e_decoded)
-    if ephemeral_json["request_time"] + 300 < int(time.time()):
-        LOGGER.info("Ephemeral link has expired.")
-        raise HTTPException(status_code=404, detail="User data not found")
 
-    # TODO: probably should be a keyed hash to catch attempts to pass an incorrect link early
     payload_digest: str = hash_from_str(
-        ephemeral_json["payload_b64"] + ephemeral_json["iv_b64"] + str(ephemeral_json["request_time"])
+        ephemeral_json["payload_b64"] + ephemeral_json["iv_b64"], TAKDataPackage.get_ephemeral_hmac_key()
     )
     if payload_digest != ephemeral_json["digest"]:
         LOGGER.info(
@@ -185,7 +178,7 @@ def parse_encrypted_ephemeral_url_fragment(ephemeral_str: str) -> tuple[str, str
     iv: bytes = base64.b64decode(ephemeral_json["iv_b64"].encode("ascii"))
     user_payload: bytes = base64.b64decode(ephemeral_json["payload_b64"].encode("ascii"))
 
-    decryptor = Cipher(algorithms.AES(TAKDataPackage.get_ephemeral_byteskey()), modes.GCM(iv)).encryptor()
+    decryptor = Cipher(algorithms.AES(TAKDataPackage.get_ephemeral_aes_key()), modes.GCM(iv)).encryptor()
     decrypted_payload = decryptor.update(user_payload) + decryptor.finalize()
 
     try:
@@ -197,6 +190,10 @@ def parse_encrypted_ephemeral_url_fragment(ephemeral_str: str) -> tuple[str, str
     variant = decrypted_json["variant"]
     callsign = decrypted_json["callsign"]
     user_uuid = decrypted_json["uuid"]
+    link_generation_time = decrypted_json["request_time"]
+    if link_generation_time + 300 < int(time.time()):
+        LOGGER.info("Ephemeral link has expired.")
+        raise HTTPException(status_code=404, detail="User data not found")
 
     LOGGER.debug("Got the following data in ephemeral user payload: {}".format(decrypted_json))
 

--- a/src/takrmapi/app.py
+++ b/src/takrmapi/app.py
@@ -8,7 +8,7 @@ from contextlib import asynccontextmanager
 import filelock
 
 from fastapi import FastAPI
-from libpvarki.logging import init_logging
+from libpvarki.logging import init_logging, add_trace_and_audit
 
 from takrmapi import __version__
 from takrmapi import config
@@ -63,6 +63,7 @@ def get_app_no_init() -> FastAPI:
 
 def get_app() -> FastAPI:
     """Returns the FastAPI application."""
+    add_trace_and_audit()
     init_logging(LOG_LEVEL)
     app = get_app_no_init()
     LOGGER.info("API init done, setting log verbosity to '{}'.".format(logging.getLevelName(LOG_LEVEL)))

--- a/src/takrmapi/takutils/tak_pkg_helpers.py
+++ b/src/takrmapi/takutils/tak_pkg_helpers.py
@@ -2,6 +2,7 @@
 
 import base64
 import binascii
+import hashlib
 from typing import List, Any, Dict, ClassVar
 import logging
 from dataclasses import dataclass, field
@@ -36,21 +37,22 @@ class TAKPkgVars:
     template_file_render_str: str
 
 
-def _get_secret_key_from_environ() -> bytes:
+def _get_secret_key_from_environ(key_descriptor: str = "KEY") -> bytes:
     """Fetch the secret key from the environment variable."""
 
     from_env = os.environ.get("TAKRMAPI_SECRET_KEY", "")
     try:
         key_candidate = base64.b64decode(from_env.encode("ascii"))
-    except (TypeError, binascii.Error):
-        LOGGER.warning("TAKRMAPI_SECRET_KEY is not valid base64 encoded string.")
-        return b""
+    except (TypeError, binascii.Error) as e:
+        raise RuntimeError("TAKRMAPI_SECRET_KEY is not valid base64 encoded string.") from e
 
-    if len(key_candidate) >= 32:
-        return key_candidate[:32]
+    if len(key_candidate) < 32:
+        raise RuntimeError("TAKRMAPI_SECRET_KEY is too short. It should be at least 32 bytes long.")
 
-    LOGGER.warning("TAKRMAPI_SECRET_KEY is too short. It should be at least 32 bytes long.")
-    return b""
+    sha256 = hashlib.sha256()
+    sha256.update(key_candidate)
+    sha256.update(key_descriptor.encode("ascii"))
+    return sha256.digest()
 
 
 @dataclass
@@ -61,7 +63,8 @@ class TAKDataPackage:
     template_type: str
 
     _pkgvars: TAKPkgVars = field(init=False)
-    ephemeral_key: ClassVar[bytes] = b""
+    _ephemeral_aes_key: ClassVar[bytes] = b""
+    _ephemeral_hmac_key: ClassVar[bytes] = b""
 
     # TODO savolaiset muuttujat
     # _zip_path: Path = field(init=False)
@@ -99,14 +102,20 @@ class TAKDataPackage:
         )
 
     @classmethod
-    def get_ephemeral_byteskey(cls) -> bytes:
+    def get_ephemeral_aes_key(cls) -> bytes:
         """Return key for ephemeral file requests"""
-        if not cls.ephemeral_key:
-            cls.ephemeral_key = _get_secret_key_from_environ()
-            if not cls.ephemeral_key:
-                raise RuntimeError("Ephemeral key not set!")
+        if not cls._ephemeral_aes_key:
+            cls._ephemeral_aes_key = _get_secret_key_from_environ("AESKEY")
 
-        return cls.ephemeral_key
+        return cls._ephemeral_aes_key
+
+    @classmethod
+    def get_ephemeral_hmac_key(cls) -> bytes:
+        """Return key for ephemeral file requests"""
+        if not cls._ephemeral_hmac_key:
+            cls._ephemeral_hmac_key = _get_secret_key_from_environ("HMACKEY")
+
+        return cls._ephemeral_hmac_key
 
     @property
     def is_folder(self) -> bool:

--- a/tests/test_takrmapi.py
+++ b/tests/test_takrmapi.py
@@ -20,7 +20,7 @@ from takrmapi.takutils.tak_pkg_helpers import TAKDataPackage
 
 def test_version() -> None:
     """Make sure version matches expected"""
-    assert __version__ == "1.10.2"
+    assert __version__ == "1.11.0"
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_takrmapi.py
+++ b/tests/test_takrmapi.py
@@ -24,7 +24,7 @@ def test_version() -> None:
 @pytest.fixture(autouse=True)
 def clear_encryption_keys() -> None:
     """Clear ephemeral keys between tests."""
-    TAKDataPackage.ephemeral_key = b""
+    TAKDataPackage._ephemeral_aes_key = b""
 
 
 @mock.patch("os.environ", {"TAKRMAPI_SECRET_KEY": base64.b64encode(token_bytes(32)).decode("utf-8")})
@@ -49,6 +49,10 @@ EXAMPLE_KEY = "zyygdR6MGvmCe+Dm5hDMdQqTJa7VNc451SyQrirUXUI="  # pragma: allowlis
 @mock.patch("os.environ", {"TAKRMAPI_SECRET_KEY": EXAMPLE_KEY})
 def test_ephemeral_key_loading() -> None:
     """Verify that ephemeral key loading works as expected."""
-    assert TAKDataPackage.get_ephemeral_byteskey() != b""
-    assert len(TAKDataPackage.get_ephemeral_byteskey()) == 32
-    assert base64.b64encode(TAKDataPackage.get_ephemeral_byteskey()).decode("ascii") == EXAMPLE_KEY
+    assert TAKDataPackage.get_ephemeral_aes_key() != b""
+    assert len(TAKDataPackage.get_ephemeral_aes_key()) == 32
+    assert base64.b64encode(TAKDataPackage.get_ephemeral_aes_key()).decode("ascii") != EXAMPLE_KEY
+    assert len(TAKDataPackage.get_ephemeral_hmac_key()) == 32
+    assert base64.b64encode(TAKDataPackage.get_ephemeral_hmac_key()).decode("ascii") != EXAMPLE_KEY
+
+    assert TAKDataPackage.get_ephemeral_hmac_key() != TAKDataPackage.get_ephemeral_aes_key()

--- a/tests/test_takrmapi.py
+++ b/tests/test_takrmapi.py
@@ -8,6 +8,8 @@ from unittest import mock
 
 import pytest
 
+from fastapi import HTTPException
+
 from takrmapi import __version__
 from takrmapi.api.tak_missionpackage import (
     generate_encrypted_ephemeral_url_fragment,
@@ -24,7 +26,7 @@ def test_version() -> None:
 @pytest.fixture(autouse=True)
 def clear_encryption_keys() -> None:
     """Clear ephemeral keys between tests."""
-    TAKDataPackage._ephemeral_aes_key = b""
+    TAKDataPackage._ephemeral_aes_key = b""  # pylint: disable=protected-access
 
 
 @mock.patch("os.environ", {"TAKRMAPI_SECRET_KEY": base64.b64encode(token_bytes(32)).decode("utf-8")})
@@ -41,6 +43,23 @@ def test_ephemeral_link_generation() -> None:
     assert gotten_callsign == callsign
     assert gotten_uuid == uuid
     assert gotten_variant == "testvariant"
+
+
+@mock.patch("os.environ", {"TAKRMAPI_SECRET_KEY": base64.b64encode(token_bytes(32)).decode("utf-8")})
+def test_ephemeral_link_expired_audit_log(caplog: pytest.LogCaptureFixture) -> None:
+    """Verify that an expired ephemeral link (6 min old) raises 404 and generates an audit log entry."""
+    six_minutes_ago = time.time() - 360
+    callsign = "N0CALL"
+    uuid = "12345678-1234-5678-1234-567812345678"
+
+    encrypted_url = generate_encrypted_ephemeral_url_fragment(callsign, uuid, "testvariant", six_minutes_ago)
+
+    with caplog.at_level("AUDIT", logger="takrmapi.api.tak_missionpackage"):
+        with pytest.raises(HTTPException) as exc_info:
+            parse_encrypted_ephemeral_url_fragment(encrypted_url)
+
+    assert exc_info.value.status_code == 404
+    assert "Ephemeral link has expired." in caplog.text
 
 
 EXAMPLE_KEY = "zyygdR6MGvmCe+Dm5hDMdQqTJa7VNc451SyQrirUXUI="  # pragma: allowlist secret


### PR DESCRIPTION
Move the data inside the encrypted content. Use a keyed hash to verify payload integrity to avoid decryption oracle attacks.

Base distribution update to noble. The Ubuntu jammy with python3.10 base was conflicting with new libpvarki dependencies.

## Why It's Good for the Product (Release Goal)

- Attacker is not able to access the package by modifying the URL
- Fresher base distro with less vulnerabilities