### PR TITLE
Make `takrmapi.takutils` read timeout values from environment

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.12.0
+current_version = 1.12.1
 commit = False
 tag = False
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.1.7-experimental
 ARG TEMURIN_VERSION="17"
 ARG TAKSERVER_IMAGE="pvarki/takserver:5.7-RELEASE-8"
+ARG PYPI_INDEX_URL=https://pypi.org/simple
 
 # The local reference tak_server is used in future stages
 FROM ${TAKSERVER_IMAGE} as tak_server
@@ -28,6 +29,7 @@ RUN export RESOLVED_VERSIONS=`pyenv_resolve $PYTHON_VERSIONS` \
 ######################
 FROM eclipse-temurin:${TEMURIN_VERSION}-noble as builder_base
 #FROM python:3.11-bookworm as builder_base
+ARG PYPI_INDEX_URL
 ENV \
   # locale
   LC_ALL=C.UTF-8 \
@@ -39,8 +41,8 @@ ENV \
   PIP_NO_CACHE_DIR=off \
   PIP_DISABLE_PIP_VERSION_CHECK=on \
   PIP_DEFAULT_TIMEOUT=100 \
-  PIP_INDEX_URL=https://nexus.dev.pvarki.fi/repository/python/simple \
-  POETRY_PYPI_MIRROR_URL=https://nexus.dev.pvarki.fi/repository/python/simple \
+  PIP_INDEX_URL=${PYPI_INDEX_URL} \
+  POETRY_PYPI_MIRROR_URL=${PYPI_INDEX_URL} \
   # poetry:
   POETRY_VERSION=2.2.1
 RUN apt-get update && apt-get install -y \
@@ -110,6 +112,7 @@ RUN --mount=type=ssh source /.venv/bin/activate \
 # Main production build #
 #########################
 FROM eclipse-temurin:${TEMURIN_VERSION}-noble as production
+ARG PYPI_INDEX_URL
 COPY --from=production_build /tmp/wheelhouse /tmp/wheelhouse
 COPY --from=production_build /ui_build /ui_build
 COPY --from=production_build /docker-entrypoint.sh /docker-entrypoint.sh
@@ -137,7 +140,7 @@ RUN --mount=type=ssh apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/* \
     && chmod a+x /docker-entrypoint.sh \
     && WHEELFILE=`echo /tmp/wheelhouse/takrmap*.whl` \
-    && pip3 install --break-system-packages --index-url https://nexus.dev.pvarki.fi/repository/python/simple --find-links=/tmp/wheelhouse/ "$WHEELFILE"[all] \
+    && pip3 install --break-system-packages --index-url ${PYPI_INDEX_URL} --find-links=/tmp/wheelhouse/ "$WHEELFILE"[all] \
     && rm -rf /tmp/wheelhouse/ \
     # Make some directories
     && mkdir -p /opt/tak/data/certs \
@@ -175,7 +178,7 @@ ENTRYPOINT ["/usr/bin/tini", "--", "docker/entrypoint-test.sh"]
 RUN --mount=type=ssh source /.venv/bin/activate \
     && poetry install --no-interaction --no-ansi \
     && ln -s /app/docker/container-init.sh /container-init.sh \
-    && SKIP="poetry-lock" poetry run docker/pre_commit_init.sh \
+    && SKIP="poetry-lock" PIP_EXTRA_INDEX_URL= poetry run docker/pre_commit_init.sh \
     && true
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "takrmapi"
-version = "1.12.0"
+version = "1.12.1"
 description = "RASENMAEHER integration API for TAK server"
 authors = ["Eero af Heurlin <rambo@iki.fi>", "Ari Karhunen <FIXME@example.com>"]
 homepage = "https://github.com/pvarki/python-tak-rmapi"

--- a/src/takrmapi/__init__.py
+++ b/src/takrmapi/__init__.py
@@ -1,3 +1,3 @@
 """RASENMAEHER integration API for TAK server"""
 
-__version__ = "1.12.0"  # NOTE Use `bump2version --config-file patch` to bump versions correctly
+__version__ = "1.12.1"  # NOTE Use `bump2version --config-file patch` to bump versions correctly

--- a/src/takrmapi/takutils/env_helpers.py
+++ b/src/takrmapi/takutils/env_helpers.py
@@ -1,0 +1,21 @@
+"""Helpers for reading typed values from environment variables"""
+
+import os
+import logging
+
+LOGGER = logging.getLogger(__name__)
+
+
+def env_float(key: str, default: float, min_value: float = 0.0, max_value: float = float("inf")) -> float:
+    """Read a float from an environment variable with exclusive bounds (min_value, max_value).
+
+    Values that are out of range, non-numeric, or infinite fall back to the default.
+    """
+    try:
+        value = float(os.getenv(key) or default)
+        if not min_value < value < max_value:
+            raise ValueError(f"{value} out of range ({min_value}, {max_value})")
+        return value
+    except (TypeError, ValueError):
+        LOGGER.warning("Invalid value for %s, using default %s", key, default)
+        return default

--- a/src/takrmapi/takutils/env_helpers.py
+++ b/src/takrmapi/takutils/env_helpers.py
@@ -6,15 +6,18 @@ import logging
 LOGGER = logging.getLogger(__name__)
 
 
-def env_float(key: str, default: float, min_value: float = 0.0, max_value: float = float("inf")) -> float:
-    """Read a float from an environment variable with exclusive bounds (min_value, max_value).
+def env_float(key: str, default: float, min_value: float = 0.0, max_value: float = 600.0) -> float:
+    """Read a float from an environment variable with inclusive bounds [min_value, max_value].
 
-    Values that are out of range, non-numeric, or infinite fall back to the default.
+    Raises ValueError immediately if default is outside the allowed range, as that is a
+    programming error. Invalid or out-of-range env var values fall back to the default.
     """
+    if not min_value <= default <= max_value:
+        raise ValueError(f"default {default} is outside allowed range [{min_value}, {max_value}]")
     try:
         value = float(os.getenv(key) or default)
-        if not min_value < value < max_value:
-            raise ValueError(f"{value} out of range ({min_value}, {max_value})")
+        if not min_value <= value <= max_value:
+            raise ValueError(f"{value} out of range [{min_value}, {max_value}]")
         return value
     except (TypeError, ValueError):
         LOGGER.warning("Invalid value for %s, using default %s", key, default)

--- a/src/takrmapi/takutils/tak_helpers.py
+++ b/src/takrmapi/takutils/tak_helpers.py
@@ -21,8 +21,8 @@ from takrmapi import config
 
 
 LOGGER = logging.getLogger(__name__)
-SHELL_TIMEOUT = 5.0
-KEYPAIR_TIMEOUT = 5.0
+SHELL_TIMEOUT = os.getenv("TAK_RMAPI_SHELL_TIMEOUT", 5.0)
+KEYPAIR_TIMEOUT = os.getenv("TAK_RMAPI_KEYPAIR_TIMEOUT", 5.0)
 
 # FIXME: Convert the helpers to dataclasses
 

--- a/src/takrmapi/takutils/tak_helpers.py
+++ b/src/takrmapi/takutils/tak_helpers.py
@@ -18,11 +18,12 @@ from libpvarki.shell import call_cmd
 
 
 from takrmapi import config
-
+from takrmapi.takutils.env_helpers import env_float
 
 LOGGER = logging.getLogger(__name__)
-SHELL_TIMEOUT = os.getenv("TAK_RMAPI_SHELL_TIMEOUT", 5.0)
-KEYPAIR_TIMEOUT = os.getenv("TAK_RMAPI_KEYPAIR_TIMEOUT", 5.0)
+
+SHELL_TIMEOUT = env_float("TAK_RMAPI_SHELL_TIMEOUT", 5.0, max_value=600.0)
+KEYPAIR_TIMEOUT = env_float("TAK_RMAPI_KEYPAIR_TIMEOUT", 5.0, max_value=600.0)
 
 # FIXME: Convert the helpers to dataclasses
 

--- a/src/takrmapi/takutils/tak_pkg_helpers.py
+++ b/src/takrmapi/takutils/tak_pkg_helpers.py
@@ -15,13 +15,14 @@ from jinja2 import Template
 
 from libpvarki.mtlshelp.pkcs12 import convert_pem_to_pkcs12
 from takrmapi import config
+from takrmapi.takutils.env_helpers import env_float
 from takrmapi.takutils.tak_helpers import UserCRUD, Helpers
 from takrmapi.takutils.tak_pkg_vars import TAKDataPackagePathVars, TAKViteAssetVars, UserTAKTemplateVars
 
 
 LOGGER = logging.getLogger(__name__)
 SHELL_TIMEOUT = 5.0
-KEYPAIR_TIMEOUT = 5.0
+KEYPAIR_TIMEOUT = env_float("TAK_RMAPI_KEYPAIR_TIMEOUT", 5.0, max_value=600.0)
 
 
 @dataclass

--- a/src/takrmapi/takutils/tak_pkg_helpers.py
+++ b/src/takrmapi/takutils/tak_pkg_helpers.py
@@ -21,7 +21,6 @@ from takrmapi.takutils.tak_pkg_vars import TAKDataPackagePathVars, TAKViteAssetV
 
 
 LOGGER = logging.getLogger(__name__)
-SHELL_TIMEOUT = 5.0
 KEYPAIR_TIMEOUT = env_float("TAK_RMAPI_KEYPAIR_TIMEOUT", 5.0, max_value=600.0)
 
 

--- a/src/takrmapi/takutils/tak_pkg_vars.py
+++ b/src/takrmapi/takutils/tak_pkg_vars.py
@@ -11,8 +11,6 @@ from takrmapi.takutils.tak_helpers import UserCRUD
 
 
 LOGGER = logging.getLogger(__name__)
-SHELL_TIMEOUT = 5.0
-KEYPAIR_TIMEOUT = 5.0
 
 
 @dataclass

--- a/src/takrmapi/takutils/tak_rest_helpers.py
+++ b/src/takrmapi/takutils/tak_rest_helpers.py
@@ -14,8 +14,6 @@ from takrmapi.takutils.tak_pkg_helpers import TAKDataPackage
 
 
 LOGGER = logging.getLogger(__name__)
-SHELL_TIMEOUT = 5.0
-KEYPAIR_TIMEOUT = 5.0
 
 # FIXME: Convert the helpers to dataclasses
 

--- a/tests/test_env_helpers.py
+++ b/tests/test_env_helpers.py
@@ -5,13 +5,13 @@ import pytest
 from takrmapi.takutils.env_helpers import env_float
 
 
-def testenv_float_happy_float(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_env_float_happy_float(monkeypatch: pytest.MonkeyPatch) -> None:
     """Env var set to a valid float string is returned as float."""
     monkeypatch.setenv("TEST_ENV_FLOAT", "3.14")
     assert env_float("TEST_ENV_FLOAT", 1.0) == pytest.approx(3.14)
 
 
-def testenv_float_happy_int(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_env_float_happy_int(monkeypatch: pytest.MonkeyPatch) -> None:
     """Env var set to an integer string is coerced to float."""
     monkeypatch.setenv("TEST_ENV_FLOAT", "10")
     result = env_float("TEST_ENV_FLOAT", 1.0)
@@ -19,70 +19,94 @@ def testenv_float_happy_int(monkeypatch: pytest.MonkeyPatch) -> None:
     assert result == pytest.approx(10.0)
 
 
-def testenv_float_illegal_value(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_env_float_illegal_value(monkeypatch: pytest.MonkeyPatch) -> None:
     """Env var set to a non-numeric string falls back to the default."""
     monkeypatch.setenv("TEST_ENV_FLOAT", "not_a_number")
     assert env_float("TEST_ENV_FLOAT", 5.0) == pytest.approx(5.0)
 
 
-def testenv_float_illegal_value_emits_warning(
+def test_env_float_illegal_value_emits_warning(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Illegal env var value produces a WARNING log entry and returns the default."""
     monkeypatch.setenv("TEST_ENV_FLOAT", "bad")
     with caplog.at_level("WARNING", logger="takrmapi.takutils.env_helpers"):
         result = env_float("TEST_ENV_FLOAT", 25.0)
-
-    # Verify that having an illegal value gets logged
     assert "TEST_ENV_FLOAT" in caplog.text
-
-    # and that the default value is returned instead
     assert result == pytest.approx(25.0)
 
 
-def testenv_float_exceeds_max_uses_default(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_env_float_exceeds_max_uses_default(monkeypatch: pytest.MonkeyPatch) -> None:
     """Value above max_value falls back to the default."""
     monkeypatch.setenv("TEST_ENV_FLOAT", "601")
     assert env_float("TEST_ENV_FLOAT", 5.0, max_value=600.0) == pytest.approx(5.0)
 
 
-def testenv_float_missing_uses_default(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_env_float_at_max_boundary_is_accepted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Value exactly at max_value is accepted (inclusive upper bound)."""
+    monkeypatch.setenv("TEST_ENV_FLOAT", "600")
+    assert env_float("TEST_ENV_FLOAT", 5.0, max_value=600.0) == pytest.approx(600.0)
+
+
+def test_env_float_missing_uses_default(monkeypatch: pytest.MonkeyPatch) -> None:
     """Absent env var returns the default value."""
     monkeypatch.delenv("TEST_ENV_FLOAT", raising=False)
     assert env_float("TEST_ENV_FLOAT", 7.5) == pytest.approx(7.5)
 
 
-def testenv_float_empty_string_uses_default(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_env_float_empty_string_uses_default(monkeypatch: pytest.MonkeyPatch) -> None:
     """Empty string env var is treated as unset and returns the default."""
     monkeypatch.setenv("TEST_ENV_FLOAT", "")
     assert env_float("TEST_ENV_FLOAT", 2.0) == pytest.approx(2.0)
 
 
-def testenv_float_zero_uses_default(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Zero is out of the default (0, inf) range and falls back to the default."""
+def test_env_float_at_min_boundary_is_accepted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Value exactly at min_value is accepted (inclusive lower bound)."""
     monkeypatch.setenv("TEST_ENV_FLOAT", "0")
-    assert env_float("TEST_ENV_FLOAT", 5.0) == pytest.approx(5.0)
+    assert env_float("TEST_ENV_FLOAT", 0.0) == pytest.approx(0.0)
 
 
-def testenv_float_negative_uses_default(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Negative value is out of range and falls back to the default."""
+def test_env_float_negative_uses_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Negative value is below min_value and falls back to the default."""
     monkeypatch.setenv("TEST_ENV_FLOAT", "-1.0")
     assert env_float("TEST_ENV_FLOAT", 5.0) == pytest.approx(5.0)
 
 
-def testenv_float_inf_uses_default(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Infinity would disable timeouts entirely, so it falls back to the default."""
+def test_env_float_inf_uses_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Infinity exceeds the default max_value of 600.0 and falls back to the default."""
     monkeypatch.setenv("TEST_ENV_FLOAT", "inf")
     assert env_float("TEST_ENV_FLOAT", 5.0) == pytest.approx(5.0)
 
 
-def testenv_float_nan_uses_default(monkeypatch: pytest.MonkeyPatch) -> None:
-    """NaN is out of range and falls back to the default."""
+def test_env_float_nan_uses_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """NaN fails all comparisons and falls back to the default."""
     monkeypatch.setenv("TEST_ENV_FLOAT", "nan")
     assert env_float("TEST_ENV_FLOAT", 5.0) == pytest.approx(5.0)
 
 
-def testenv_float_whitespace_padded(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_env_float_whitespace_padded(monkeypatch: pytest.MonkeyPatch) -> None:
     """Whitespace-padded numeric string is accepted since float() strips whitespace."""
     monkeypatch.setenv("TEST_ENV_FLOAT", "  3.14  ")
     assert env_float("TEST_ENV_FLOAT", 1.0) == pytest.approx(3.14)
+
+
+def test_env_float_falsy_default_missing_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Absent env var falls back to a falsy default of 0.0 correctly.
+
+    0.0 is falsy in Python, so the 'os.getenv(key) or default' expression
+    must be evaluated carefully: None or 0.0 yields 0.0, not a silent discard.
+    """
+    monkeypatch.delenv("TEST_ENV_FLOAT", raising=False)
+    assert env_float("TEST_ENV_FLOAT", 0.0) == pytest.approx(0.0)
+
+
+def test_env_float_invalid_default_raises() -> None:
+    """A default outside the allowed range raises ValueError immediately at startup."""
+    with pytest.raises(ValueError, match="default .* is outside allowed range"):
+        env_float("TEST_ENV_FLOAT", 9999.0, max_value=600.0)
+
+
+def test_env_float_inverted_bounds_raises() -> None:
+    """min_value > max_value is a programming error caught via the default validation."""
+    with pytest.raises(ValueError, match="default .* is outside allowed range"):
+        env_float("TEST_ENV_FLOAT", 5.0, min_value=100.0, max_value=10.0)

--- a/tests/test_env_helpers.py
+++ b/tests/test_env_helpers.py
@@ -1,0 +1,88 @@
+"""Tests for env_helpers"""
+
+import pytest
+
+from takrmapi.takutils.env_helpers import env_float
+
+
+def testenv_float_happy_float(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Env var set to a valid float string is returned as float."""
+    monkeypatch.setenv("TEST_ENV_FLOAT", "3.14")
+    assert env_float("TEST_ENV_FLOAT", 1.0) == pytest.approx(3.14)
+
+
+def testenv_float_happy_int(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Env var set to an integer string is coerced to float."""
+    monkeypatch.setenv("TEST_ENV_FLOAT", "10")
+    result = env_float("TEST_ENV_FLOAT", 1.0)
+    assert isinstance(result, float)
+    assert result == pytest.approx(10.0)
+
+
+def testenv_float_illegal_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Env var set to a non-numeric string falls back to the default."""
+    monkeypatch.setenv("TEST_ENV_FLOAT", "not_a_number")
+    assert env_float("TEST_ENV_FLOAT", 5.0) == pytest.approx(5.0)
+
+
+def testenv_float_illegal_value_emits_warning(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Illegal env var value produces a WARNING log entry and returns the default."""
+    monkeypatch.setenv("TEST_ENV_FLOAT", "bad")
+    with caplog.at_level("WARNING", logger="takrmapi.takutils.env_helpers"):
+        result = env_float("TEST_ENV_FLOAT", 25.0)
+
+    # Verify that having an illegal value gets logged
+    assert "TEST_ENV_FLOAT" in caplog.text
+
+    # and that the default value is returned instead
+    assert result == pytest.approx(25.0)
+
+
+def testenv_float_exceeds_max_uses_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Value above max_value falls back to the default."""
+    monkeypatch.setenv("TEST_ENV_FLOAT", "601")
+    assert env_float("TEST_ENV_FLOAT", 5.0, max_value=600.0) == pytest.approx(5.0)
+
+
+def testenv_float_missing_uses_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Absent env var returns the default value."""
+    monkeypatch.delenv("TEST_ENV_FLOAT", raising=False)
+    assert env_float("TEST_ENV_FLOAT", 7.5) == pytest.approx(7.5)
+
+
+def testenv_float_empty_string_uses_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty string env var is treated as unset and returns the default."""
+    monkeypatch.setenv("TEST_ENV_FLOAT", "")
+    assert env_float("TEST_ENV_FLOAT", 2.0) == pytest.approx(2.0)
+
+
+def testenv_float_zero_uses_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Zero is out of the default (0, inf) range and falls back to the default."""
+    monkeypatch.setenv("TEST_ENV_FLOAT", "0")
+    assert env_float("TEST_ENV_FLOAT", 5.0) == pytest.approx(5.0)
+
+
+def testenv_float_negative_uses_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Negative value is out of range and falls back to the default."""
+    monkeypatch.setenv("TEST_ENV_FLOAT", "-1.0")
+    assert env_float("TEST_ENV_FLOAT", 5.0) == pytest.approx(5.0)
+
+
+def testenv_float_inf_uses_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Infinity would disable timeouts entirely, so it falls back to the default."""
+    monkeypatch.setenv("TEST_ENV_FLOAT", "inf")
+    assert env_float("TEST_ENV_FLOAT", 5.0) == pytest.approx(5.0)
+
+
+def testenv_float_nan_uses_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """NaN is out of range and falls back to the default."""
+    monkeypatch.setenv("TEST_ENV_FLOAT", "nan")
+    assert env_float("TEST_ENV_FLOAT", 5.0) == pytest.approx(5.0)
+
+
+def testenv_float_whitespace_padded(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Whitespace-padded numeric string is accepted since float() strips whitespace."""
+    monkeypatch.setenv("TEST_ENV_FLOAT", "  3.14  ")
+    assert env_float("TEST_ENV_FLOAT", 1.0) == pytest.approx(3.14)

--- a/tests/test_takrmapi.py
+++ b/tests/test_takrmapi.py
@@ -20,7 +20,7 @@ from takrmapi.takutils.tak_pkg_helpers import TAKDataPackage
 
 def test_version() -> None:
     """Make sure version matches expected"""
-    assert __version__ == "1.12.0"
+    assert __version__ == "1.12.1"
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## User-facing summary
Fix to a feature:
- Added helper function `takrmapi.takutils.env_helpers.env_float` to be able override timeout values from environment values
- Added unit tests to verify correct operation
- Removed unused timeout variables from other modules in `takrmapi.takutils.*`

## Why It's Good for the Product (Release Goal)
- Kubernetes environment (especially resource-constrained) requires longer timeouts (current 5s is too short and in K8s takrmapi couldn't enroll users to TAK)

## Any Other You'd Like to Mention
- It turns out that in user enrollment, the shell scripts fire up a new JVM one per script. So at least 3 per each admin user. This takes easily several seconds, and more in a resource-constrained enviroment.
