### PR TITLE
Feat: Sync Streams from Mediamtx to TAK Server

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.12.1
+current_version = 1.12.2
 commit = False
 tag = False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "takrmapi"
-version = "1.12.1"
+version = "1.12.2"
 description = "RASENMAEHER integration API for TAK server"
 authors = ["Eero af Heurlin <rambo@iki.fi>", "Ari Karhunen <FIXME@example.com>"]
 homepage = "https://github.com/pvarki/python-tak-rmapi"

--- a/src/takrmapi/__init__.py
+++ b/src/takrmapi/__init__.py
@@ -1,3 +1,3 @@
 """RASENMAEHER integration API for TAK server"""
 
-__version__ = "1.12.1"  # NOTE Use `bump2version --config-file patch` to bump versions correctly
+__version__ = "1.12.2"  # NOTE Use `bump2version --config-file patch` to bump versions correctly

--- a/src/takrmapi/app.py
+++ b/src/takrmapi/app.py
@@ -4,7 +4,7 @@ import asyncio
 import random
 from typing import AsyncGenerator
 import logging
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 import filelock
 
 from fastapi import FastAPI
@@ -13,6 +13,7 @@ from libpvarki.logging import init_logging, add_trace_and_audit
 from takrmapi import __version__
 from takrmapi import config
 from takrmapi.takutils import tak_init
+from takrmapi.takutils.stream_sync import MediaMTXTakSync
 from .config import LOG_LEVEL
 from .api import all_routers, all_routers_v2, all_routers_ephemeral_v1
 
@@ -29,15 +30,18 @@ async def app_lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # Random sleep to the lock file access to avoid race conditions
     await asyncio.sleep(random.random() / 2)  # nosec
     lock = filelock.FileLock(lockpath)
+    init_lock_acquired = False
 
     try:
         lock.acquire(timeout=0.0)
+        init_lock_acquired = True
         await tak_init.setup_tak_mgmt_conn()
         await tak_init.setup_tak_defaults()
     except filelock.Timeout:
         LOGGER.warning("Someone has already locked {}, leaving this init to them".format(lockpath))
     finally:
-        lock.release()
+        if init_lock_acquired:
+            lock.release()
 
     # Wait for the init to be completed
     while lock.is_locked:
@@ -46,10 +50,29 @@ async def app_lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     await tak_init.get_tak_defaults()
 
+    sync_task: asyncio.Task[None] | None = None
+    sync_lock: filelock.FileLock | None = None
+    if config.STREAM_SYNC_ENABLED:
+        sync_lock = filelock.FileLock(config.TAK_CERTS_FOLDER / "takrmapi_stream_sync.lock")
+        try:
+            sync_lock.acquire(timeout=0.0)
+        except filelock.Timeout:
+            LOGGER.info("Another worker owns %s, skipping MediaMTX sync worker startup", sync_lock.lock_file)
+            sync_lock = None
+        else:
+            LOGGER.info("Acquired %s, starting MediaMTX sync worker", sync_lock.lock_file)
+            sync_task = asyncio.create_task(MediaMTXTakSync().run_forever())
+
     _ = app
     # App runs
     yield
     # Cleanup
+    if sync_task:
+        sync_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await sync_task
+    if sync_lock is not None:
+        sync_lock.release()
 
 
 def get_app_no_init() -> FastAPI:

--- a/src/takrmapi/config.py
+++ b/src/takrmapi/config.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import json
 import functools
 import logging
+import os
 
 from starlette.config import Config
 
@@ -14,6 +15,10 @@ LOGGER = logging.getLogger(__name__)
 @functools.cache
 def load_manifest(filepth: Path = Path("/pvarki/kraftwerk-init.json")) -> Dict[str, Any]:
     """Load the manifest"""
+    if not filepth.exists():
+        altfile = Path("/pvarki/kraftwerk-rasenmaeher-init.json")
+        if altfile.exists():
+            filepth = altfile
     if not filepth.exists():
         # return a dummy manifest
         LOGGER.warning("Returning dummy manifest")
@@ -36,9 +41,69 @@ def read_tak_fqdn() -> str:
     return str(load_manifest()["product"]["dns"])
 
 
+def read_product_certcn() -> str:
+    """Read the product certificate CN from manifest."""
+    manifest = load_manifest()
+    product = cast(Dict[str, Any], manifest.get("product", {}))
+    if "certcn" in product:
+        return str(product["certcn"])
+    products = cast(Dict[str, Any], manifest.get("products", {}))
+    if "tak" in products and "certcn" in products["tak"]:
+        return str(products["tak"]["certcn"])
+    return read_tak_fqdn()
+
+
 def read_deployment_name() -> str:
     """Read the fqdn from manifest"""
     return str(load_manifest()["deployment"])
+
+
+def read_rm_mtls_base_uri() -> str:
+    """Read the RM mTLS API base URI from manifest."""
+    return str(load_manifest()["rasenmaeher"]["mtls"]["base_uri"])
+
+
+def read_product_api_base(product_name: str) -> str:
+    """Read product API base URI from manifest, with a local fallback."""
+    manifest = load_manifest()
+    products = cast(Dict[str, Any], manifest.get("products", {}))
+    if product_name in products and "api" in products[product_name]:
+        return str(products[product_name]["api"])
+    product_https_port = int(os.getenv("TI_PRODUCT_HTTPS_PORT", "4626"))
+    return f"https://{product_name}.{read_deployment_name()}.dev.pvarki.fi:{product_https_port}"
+
+
+def default_rm_product_cert_path() -> Path:
+    """Resolve the RM product client certificate path."""
+    candidates = [
+        RMAPI_PERSISTENT_FOLDER / "public" / f"{read_product_certcn()}.pem",
+        RMAPI_PERSISTENT_FOLDER / "public" / "mtlsclient.pem",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return candidates[-1]
+
+
+def default_rm_product_key_path() -> Path:
+    """Resolve the RM product client private key path."""
+    candidates = [
+        RMAPI_PERSISTENT_FOLDER / "private" / f"{read_product_certcn()}.key",
+        RMAPI_PERSISTENT_FOLDER / "private" / "mtlsclient.key",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return candidates[-1]
+
+
+def resolve_rm_product_path(configured: Path, fallback: Path) -> Path:
+    """Use configured path when present, otherwise fall back to discovered path."""
+    if configured.exists():
+        return configured
+    if configured != fallback:
+        LOGGER.warning("Configured RM product path %s missing, falling back to %s", configured, fallback)
+    return fallback
 
 
 cfg = Config(
@@ -52,6 +117,33 @@ TAK_CERTS_FOLDER: Path = cfg("TAK_CERTS_FOLDER", cast=Path, default=Path("/opt/t
 RMAPI_PERSISTENT_FOLDER: Path = cfg("RMAPI_PERSISTENT_FOLDER", cast=Path, default=Path("/data/persistent"))
 
 PRODUCT_HTTPS_EPHEMERAL_PORT: int = cfg("PRODUCT_HTTPS_EPHEMERAL_PORT", cast=int, default=4627)
+STREAM_SYNC_ENABLED: bool = cfg("STREAM_SYNC_ENABLED", cast=bool, default=False)
+STREAM_SYNC_INTERVAL: float = cfg("STREAM_SYNC_INTERVAL", cast=float, default=60.0)
+MTX_PRODUCT_NAME: str = cfg("MTX_PRODUCT_NAME", cast=str, default="mtx")
+RM_API_MTLS_BASE_URL: str = cfg("RM_API_MTLS_BASE_URL", cast=str, default=read_rm_mtls_base_uri())
+MTX_PRODUCT_API_BASE_URL: str = cfg(
+    "MTX_PRODUCT_API_BASE_URL",
+    cast=str,
+    default=read_product_api_base("mtx"),
+)
+MTX_INTEROP_STREAMS_PATH: str = cfg("MTX_INTEROP_STREAMS_PATH", cast=str, default="/api/v1/interop/streams")
+TAK_VIDEO_CLASSIFICATION: str = cfg("TAK_VIDEO_CLASSIFICATION", cast=str, default="UNCLASSIFIED")
+RM_PRODUCT_CERT_PATH: Path = resolve_rm_product_path(
+    cfg(
+        "RM_PRODUCT_CERT_PATH",
+        cast=Path,
+        default=default_rm_product_cert_path(),
+    ),
+    default_rm_product_cert_path(),
+)
+RM_PRODUCT_KEY_PATH: Path = resolve_rm_product_path(
+    cfg(
+        "RM_PRODUCT_KEY_PATH",
+        cast=Path,
+        default=default_rm_product_key_path(),
+    ),
+    default_rm_product_key_path(),
+)
 
 # TAK vite asset graphical addons
 VITE_ASSET_SET: str = cfg("VITE_ASSET_SET", cast=str, default="not_used_by_default")

--- a/src/takrmapi/takutils/stream_sync.py
+++ b/src/takrmapi/takutils/stream_sync.py
@@ -1,0 +1,255 @@
+"""MediaMTX -> TAK video sync helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence, cast
+import asyncio
+import hashlib
+import logging
+import ssl
+
+import aiohttp
+from libpvarki.mtlshelp.context import get_ca_context
+from libpvarki.schemas.product import UserCRUDRequest
+
+from takrmapi import config
+from takrmapi.takutils.tak_helpers import UserCRUD
+from takrmapi.takutils.tak_rest_helpers import RestHelpers
+
+LOGGER = logging.getLogger(__name__)
+MANAGED_VIDEO_PREFIX = "rmmtx"
+
+
+class StreamSyncError(RuntimeError):
+    """Sync input/output is invalid."""
+
+
+@dataclass(frozen=True)
+class VideoSyncPlan:
+    """Planned TAK mutations for a sync pass."""
+
+    create: list[dict[str, Any]]
+    update: list[dict[str, Any]]
+    delete: list[str]
+
+
+def managed_uid_prefix(deployment: str | None = None) -> str:
+    """Return the TAK uid prefix reserved for this sync worker."""
+    deployment_name = deployment or config.read_deployment_name()
+    return f"{MANAGED_VIDEO_PREFIX}-{deployment_name}-"
+
+
+def managed_video_uuid(path: str, deployment: str | None = None) -> str:
+    """Return a deterministic TAK uuid for a MediaMTX path."""
+    deployment_name = deployment or config.read_deployment_name()
+    digest = hashlib.sha256(f"{deployment_name}:{path}".encode("utf-8")).hexdigest()[:16]
+    return f"{managed_uid_prefix(deployment_name)}{digest}"
+
+
+def _normalize_uuid(payload: Mapping[str, Any]) -> str:
+    """Get uuid/uid from TAK payloads."""
+    uuid = payload.get("uuid", payload.get("uid", ""))
+    return str(uuid)
+
+
+def build_video_connection(stream: Mapping[str, Any]) -> dict[str, Any]:
+    """Build a TAK VideoConnection payload from a TAK-facing stream inventory item."""
+    path = str(stream["path"])
+    alias = str(stream.get("alias") or path.lstrip("/"))
+    urls = stream.get("urls", {})
+    if not isinstance(urls, Mapping) or not urls.get("rtmps"):
+        raise StreamSyncError(f"Stream '{path}' does not include an RTMPS URL")
+    video_uuid = managed_video_uuid(path)
+    feed_uuid = f"{video_uuid}-feed0"
+    return {
+        "uuid": video_uuid,
+        "active": True,
+        "alias": alias,
+        "thumbnail": "",
+        "classification": config.TAK_VIDEO_CLASSIFICATION,
+        "feeds": [
+            {
+                "uuid": feed_uuid,
+                "active": True,
+                "alias": alias,
+                "url": str(urls["rtmps"]),
+                "order": 0,
+            }
+        ],
+    }
+
+
+def _normalized_feed(feed: Mapping[str, Any]) -> dict[str, Any]:
+    """Normalize a TAK feed payload for comparisons."""
+    return {
+        "uuid": _normalize_uuid(feed),
+        "active": bool(feed.get("active", True)),
+        "alias": str(feed.get("alias", "")),
+        "url": str(feed.get("url", "")),
+        "order": int(feed.get("order", 0) or 0),
+    }
+
+
+def normalized_video_connection(video: Mapping[str, Any]) -> dict[str, Any]:
+    """Normalize a TAK video connection payload for comparisons."""
+    feeds = [_normalized_feed(feed) for feed in cast(Sequence[Mapping[str, Any]], video.get("feeds", []))]
+    feeds.sort(key=lambda item: item["uuid"])
+    return {
+        "uuid": _normalize_uuid(video),
+        "active": bool(video.get("active", True)),
+        "alias": str(video.get("alias", "")),
+        "thumbnail": str(video.get("thumbnail", "")),
+        "classification": str(video.get("classification", "")),
+        "feeds": feeds,
+    }
+
+
+def plan_video_sync(
+    desired_streams: Sequence[Mapping[str, Any]],
+    existing_video_connections: Sequence[Mapping[str, Any]],
+) -> VideoSyncPlan:
+    """Compute TAK create/update/delete operations for managed video connections."""
+    desired = {item["uuid"]: item for item in [build_video_connection(stream) for stream in desired_streams]}
+    existing = {_normalize_uuid(video): video for video in existing_video_connections if _normalize_uuid(video)}
+
+    create = [payload for uuid, payload in desired.items() if uuid not in existing]
+    update = [
+        payload
+        for uuid, payload in desired.items()
+        if uuid in existing and normalized_video_connection(existing[uuid]) != normalized_video_connection(payload)
+    ]
+    delete = [uuid for uuid in existing if uuid.startswith(managed_uid_prefix()) and uuid not in desired]
+    delete.sort()
+    return VideoSyncPlan(create=create, update=update, delete=delete)
+
+
+def read_product_cert_pem() -> str:
+    """Read the product certificate used for RM product interop."""
+    if not config.RM_PRODUCT_CERT_PATH.exists():
+        raise FileNotFoundError(f"Product certificate not found: {config.RM_PRODUCT_CERT_PATH}")
+    return config.RM_PRODUCT_CERT_PATH.read_text(encoding="utf-8")
+
+
+def build_interop_request() -> dict[str, str]:
+    """Build RM interop registration payload for takrmapi."""
+    cert_pem = read_product_cert_pem().rstrip() + "\n"
+    return {
+        "certcn": config.read_product_certcn(),
+        "x509cert": cert_pem.replace("\n", "\\n"),
+    }
+
+
+class MediaMTXTakSync:
+    """Periodic MediaMTX -> TAK synchronizer."""
+
+    def __init__(self, rest_helper: RestHelpers | None = None) -> None:
+        """Initialize sync helper."""
+        user = UserCRUD(UserCRUDRequest(uuid="not_needed", callsign="mtlsclient", x509cert="not_needed"))
+        self.rest_helper = rest_helper or RestHelpers(user)
+
+    def rm_product_ssl_context(self) -> ssl.SSLContext:
+        """Build SSL context for RM product mTLS."""
+        cadir = Path("/ca_public")
+        if not cadir.is_dir():
+            raise FileNotFoundError(f"RM product CA directory not found: {cadir}")
+        sslcontext = get_ca_context(ssl.Purpose.SERVER_AUTH, cadir)
+        sslcontext.load_cert_chain(config.RM_PRODUCT_CERT_PATH, config.RM_PRODUCT_KEY_PATH)
+        return sslcontext
+
+    def product_api_connector(self) -> aiohttp.TCPConnector:
+        """Build TLS connector for product API calls."""
+        return aiohttp.TCPConnector(ssl=self.rm_product_ssl_context())
+
+    def rm_product_session(self) -> aiohttp.ClientSession:
+        """Create a product-authenticated session to RM API."""
+        return aiohttp.ClientSession(
+            base_url=config.RM_API_MTLS_BASE_URL,
+            connector=aiohttp.TCPConnector(ssl=self.rm_product_ssl_context()),
+            raise_for_status=True,
+        )
+
+    async def ensure_interop(self) -> None:
+        """Ensure takrmapi is registered for interop with rmmtxauthz via RM API."""
+        async with self.rm_product_session() as session:
+            resp = await session.post(
+                f"/api/v1/product/interop/{config.MTX_PRODUCT_NAME}", json=build_interop_request()
+            )
+            payload = await resp.json(content_type=None)
+            if resp.status != 200 or not payload.get("success"):
+                raise StreamSyncError(f"RM interop registration failed: {payload}")
+
+    async def fetch_authz(self) -> Mapping[str, Any]:
+        """Fetch brokered product authz from RM API."""
+        async with self.rm_product_session() as session:
+            resp = await session.get(f"/api/v1/product/interop/{config.MTX_PRODUCT_NAME}/authz")
+            payload = await resp.json(content_type=None)
+            if resp.status != 200:
+                raise StreamSyncError(f"RM authz fetch failed: {payload}")
+            if payload.get("type") != "basic" or not payload.get("username") or not payload.get("password"):
+                raise StreamSyncError(f"Unsupported authz payload: {payload}")
+            return payload
+
+    async def fetch_streams(self, authz: Mapping[str, Any]) -> Sequence[Mapping[str, Any]]:
+        """Fetch TAK-facing active stream inventory from rmmtxauthz."""
+        auth = aiohttp.BasicAuth(login=str(authz["username"]), password=str(authz["password"]))
+        async with aiohttp.ClientSession(
+            base_url=config.MTX_PRODUCT_API_BASE_URL,
+            auth=auth,
+            connector=self.product_api_connector(),
+            raise_for_status=True,
+        ) as session:
+            resp = await session.get(config.MTX_INTEROP_STREAMS_PATH)
+            payload = await resp.json(content_type=None)
+            if resp.status != 200 or not isinstance(payload, list):
+                raise StreamSyncError(f"Invalid stream inventory payload: {payload}")
+            return payload
+
+    async def run_once(self) -> VideoSyncPlan:
+        """Run one sync pass."""
+        await self.ensure_interop()
+        authz = await self.fetch_authz()
+        desired_streams = await self.fetch_streams(authz)
+
+        existing_resp = await self.rest_helper.tak_api_video_list()
+        if not existing_resp["success"]:
+            raise StreamSyncError(f"Unable to fetch TAK video connections: {existing_resp['data']}")
+        existing_connections = cast(
+            Sequence[Mapping[str, Any]],
+            cast(Mapping[str, Any], existing_resp["data"]).get("videoConnections", []),
+        )
+
+        plan = plan_video_sync(desired_streams, existing_connections)
+        if plan.create:
+            create_resp = await self.rest_helper.tak_api_video_create({"videoConnections": plan.create})
+            if not create_resp["success"]:
+                raise StreamSyncError(f"Unable to create TAK video connections: {create_resp['data']}")
+        for payload in plan.update:
+            update_resp = await self.rest_helper.tak_api_video_update(str(payload["uuid"]), payload)
+            if not update_resp["success"]:
+                raise StreamSyncError(
+                    f"Unable to update TAK video connection '{payload['uuid']}': {update_resp['data']}"
+                )
+        for uuid in plan.delete:
+            delete_resp = await self.rest_helper.tak_api_video_delete(uuid)
+            if not delete_resp["success"]:
+                raise StreamSyncError(f"Unable to delete TAK video connection '{uuid}': {delete_resp['data']}")
+        return plan
+
+    async def run_forever(self) -> None:
+        """Run sync periodically until cancelled."""
+        while True:
+            try:
+                plan = await self.run_once()
+                LOGGER.info(
+                    "MediaMTX sync pass complete (create=%s update=%s delete=%s)",
+                    len(plan.create),
+                    len(plan.update),
+                    len(plan.delete),
+                )
+            except asyncio.CancelledError:
+                raise
+            except (StreamSyncError, aiohttp.ClientError, OSError, ssl.SSLError, ValueError) as exc:
+                LOGGER.exception("MediaMTX sync pass failed: %s", exc)
+            await asyncio.sleep(config.STREAM_SYNC_INTERVAL)

--- a/src/takrmapi/takutils/tak_rest_helpers.py
+++ b/src/takrmapi/takutils/tak_rest_helpers.py
@@ -4,6 +4,7 @@ from typing import Any, Mapping, Union, cast, List, Dict
 import logging
 import time
 import urllib.parse
+import json
 import aiohttp
 
 
@@ -37,6 +38,16 @@ class RestHelpers:  # pylint: disable=too-few-public-methods
         """Output response to log"""
         resp_text = await resp.text()
         LOGGER.info("Response status : {}, Response text : {}".format(resp.status, resp_text))
+
+    async def response_payload(self, resp: aiohttp.ClientResponse) -> Mapping[str, Any]:
+        """Read response payload, tolerating empty bodies."""
+        try:
+            return cast(Mapping[str, Any], await resp.json(content_type=None))
+        except (aiohttp.ContentTypeError, json.JSONDecodeError):
+            text = await resp.text()
+            if not text:
+                return {}
+            return {"text": text}
 
     async def tak_api_user_list(self) -> Mapping[str, Any]:
         """Get list of users from TAK"""
@@ -265,3 +276,63 @@ allowGroupChange=false"
 
             except aiohttp.ClientError:
                 return {"success": False, "data": []}
+
+    async def tak_api_video_list(self) -> Mapping[str, Any]:
+        """List TAK video connections."""
+        async with await self.helpers.tak_mtls_client() as session:
+            try:
+                url = f"{self.helpers.tak_base_url()}/Marti/api/video"
+                resp = await session.get(url, ssl=await self.helpers.tak_mtls_client_sslcontext())
+                data = await self.response_payload(resp)
+                if resp.status == 200:
+                    return {"success": True, "data": data}
+                LOGGER.info("Unable to list TAK video connections")
+                await self.output_response_to_output(resp)
+                return {"success": False, "data": data}
+            except aiohttp.ClientError:
+                return {"success": False, "data": {}}
+
+    async def tak_api_video_create(self, payload: Mapping[str, Any]) -> Mapping[str, Any]:
+        """Create TAK video connections."""
+        async with await self.helpers.tak_mtls_client() as session:
+            try:
+                url = f"{self.helpers.tak_base_url()}/Marti/api/video"
+                resp = await session.post(url, json=payload, ssl=await self.helpers.tak_mtls_client_sslcontext())
+                data = await self.response_payload(resp)
+                if resp.status in (200, 201, 204):
+                    return {"success": True, "data": data}
+                LOGGER.info("Unable to create TAK video connection(s)")
+                await self.output_response_to_output(resp)
+                return {"success": False, "data": data}
+            except aiohttp.ClientError:
+                return {"success": False, "data": {}}
+
+    async def tak_api_video_update(self, uid: str, payload: Mapping[str, Any]) -> Mapping[str, Any]:
+        """Update a TAK video connection."""
+        async with await self.helpers.tak_mtls_client() as session:
+            try:
+                url = f"{self.helpers.tak_base_url()}/Marti/api/video/{uid}"
+                resp = await session.put(url, json=payload, ssl=await self.helpers.tak_mtls_client_sslcontext())
+                data = await self.response_payload(resp)
+                if resp.status in (200, 204):
+                    return {"success": True, "data": data}
+                LOGGER.info("Unable to update TAK video connection '{}'".format(uid))
+                await self.output_response_to_output(resp)
+                return {"success": False, "data": data}
+            except aiohttp.ClientError:
+                return {"success": False, "data": {}}
+
+    async def tak_api_video_delete(self, uid: str) -> Mapping[str, Any]:
+        """Delete a TAK video connection."""
+        async with await self.helpers.tak_mtls_client() as session:
+            try:
+                url = f"{self.helpers.tak_base_url()}/Marti/api/video/{uid}"
+                resp = await session.delete(url, ssl=await self.helpers.tak_mtls_client_sslcontext())
+                data = await self.response_payload(resp)
+                if resp.status in (200, 204):
+                    return {"success": True, "data": data}
+                LOGGER.info("Unable to delete TAK video connection '{}'".format(uid))
+                await self.output_response_to_output(resp)
+                return {"success": False, "data": data}
+            except aiohttp.ClientError:
+                return {"success": False, "data": {}}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,66 @@
+"""Tests for takrmapi application lifecycle."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import asyncio
+
+import pytest
+from fastapi import FastAPI
+
+from takrmapi import app as app_module
+
+
+@pytest.mark.asyncio
+async def test_sync_worker_runs_only_once_across_workers(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only one overlapping worker lifespan may start the periodic sync loop."""
+
+    class FakeLock:
+        held_paths: dict[Path, bool] = {}
+
+        def __init__(self, lock_file: Path) -> None:
+            self.lock_file = lock_file
+
+        def acquire(self, timeout: float = -1) -> None:
+            _ = timeout
+            if FakeLock.held_paths.get(self.lock_file, False):
+                raise app_module.filelock.Timeout(str(self.lock_file))
+            FakeLock.held_paths[self.lock_file] = True
+
+        def release(self) -> None:
+            if not FakeLock.held_paths.get(self.lock_file, False):
+                raise RuntimeError(f"Attempted to release unlocked lock {self.lock_file}")
+            FakeLock.held_paths[self.lock_file] = False
+
+        @property
+        def is_locked(self) -> bool:
+            return FakeLock.held_paths.get(self.lock_file, False)
+
+    started = 0
+    stop_event = asyncio.Event()
+
+    async def fake_setup() -> None:
+        return None
+
+    async def fake_get_defaults() -> None:
+        return None
+
+    async def fake_run_forever(self) -> None:
+        nonlocal started
+        _ = self
+        started += 1
+        await stop_event.wait()
+
+    monkeypatch.setattr(app_module.filelock, "FileLock", FakeLock)
+    monkeypatch.setattr(app_module.random, "random", lambda: 0.0)
+    monkeypatch.setattr(app_module.config, "TAK_CERTS_FOLDER", tmp_path)
+    monkeypatch.setattr(app_module.config, "STREAM_SYNC_ENABLED", True)
+    monkeypatch.setattr(app_module.tak_init, "setup_tak_mgmt_conn", fake_setup)
+    monkeypatch.setattr(app_module.tak_init, "setup_tak_defaults", fake_setup)
+    monkeypatch.setattr(app_module.tak_init, "get_tak_defaults", fake_get_defaults)
+    monkeypatch.setattr(app_module.MediaMTXTakSync, "run_forever", fake_run_forever)
+
+    async with app_module.app_lifespan(FastAPI()):
+        async with app_module.app_lifespan(FastAPI()):
+            await asyncio.sleep(0)
+            assert started == 1

--- a/tests/test_stream_sync.py
+++ b/tests/test_stream_sync.py
@@ -1,0 +1,326 @@
+"""Tests for MediaMTX -> TAK sync helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+import ssl
+
+import pytest
+
+from takrmapi import config
+from takrmapi.takutils import stream_sync as stream_sync_module
+from takrmapi.takutils.stream_sync import (
+    StreamSyncError,
+    MediaMTXTakSync,
+    build_interop_request,
+    build_video_connection,
+    managed_video_uuid,
+    plan_video_sync,
+)
+from takrmapi.takutils.tak_rest_helpers import RestHelpers
+
+
+def test_build_video_connection() -> None:
+    """TAK payload uses JSON uuid fields and RTMPS feed URLs."""
+    payload = build_video_connection(
+        {
+            "path": "/live/demo",
+            "alias": "live/demo",
+            "urls": {"rtmps": "rtmps://streams.example.test:1936/live/demo?user=user&pass=pass"},
+        }
+    )
+    assert payload["uuid"] == managed_video_uuid("/live/demo")
+    assert payload["feeds"][0]["uuid"] == f"{payload['uuid']}-feed0"
+    assert payload["feeds"][0]["url"].startswith("rtmps://")
+
+
+def test_plan_video_sync_create_update_delete() -> None:
+    """Diff logic creates, updates, and deletes only managed TAK entries."""
+    desired_streams = [
+        {
+            "path": "/live/demo",
+            "alias": "live/demo",
+            "urls": {"rtmps": "rtmps://streams.example.test:1936/live/demo?user=user&pass=pass"},
+        }
+    ]
+    existing = [
+        {
+            "uuid": managed_video_uuid("/live/demo"),
+            "active": True,
+            "alias": "old-alias",
+            "thumbnail": "",
+            "classification": config.TAK_VIDEO_CLASSIFICATION,
+            "feeds": [
+                {
+                    "uuid": f"{managed_video_uuid('/live/demo')}-feed0",
+                    "active": True,
+                    "alias": "old-alias",
+                    "url": "rtmps://streams.example.test:1936/live/demo?user=user&pass=pass",
+                    "order": 0,
+                }
+            ],
+        },
+        {
+            "uuid": managed_video_uuid("/live/stale"),
+            "active": True,
+            "alias": "live/stale",
+            "thumbnail": "",
+            "classification": config.TAK_VIDEO_CLASSIFICATION,
+            "feeds": [],
+        },
+        {
+            "uuid": "manual-video-entry",
+            "active": True,
+            "alias": "manual",
+            "thumbnail": "",
+            "classification": config.TAK_VIDEO_CLASSIFICATION,
+            "feeds": [],
+        },
+    ]
+    plan = plan_video_sync(desired_streams, existing)
+    assert plan.create == []
+    assert [item["uuid"] for item in plan.update] == [managed_video_uuid("/live/demo")]
+    assert plan.delete == [managed_video_uuid("/live/stale")]
+
+
+def test_plan_video_sync_noop() -> None:
+    """Diff logic is a no-op when TAK already matches desired state."""
+    desired_streams = [
+        {
+            "path": "/live/demo",
+            "alias": "live/demo",
+            "urls": {"rtmps": "rtmps://streams.example.test:1936/live/demo?user=user&pass=pass"},
+        }
+    ]
+    desired_video = build_video_connection(desired_streams[0])
+    plan = plan_video_sync(desired_streams, [desired_video])
+    assert plan.create == []
+    assert plan.update == []
+    assert plan.delete == []
+
+
+def test_build_interop_request(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Interop request reads and CFSSL-encodes the product cert."""
+    cert_path = tmp_path / "tak.localmaeher.dev.pvarki.fi.pem"
+    cert_path.write_text("-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----\n", encoding="utf-8")
+    monkeypatch.setattr(config, "RM_PRODUCT_CERT_PATH", cert_path)
+    monkeypatch.setattr(config, "read_product_certcn", lambda: "tak.localmaeher.dev.pvarki.fi")
+    payload = build_interop_request()
+    assert payload["certcn"] == "tak.localmaeher.dev.pvarki.fi"
+    assert payload["x509cert"] == "-----BEGIN CERTIFICATE-----\\nabc\\n-----END CERTIFICATE-----\\n"
+
+
+def test_default_rm_product_paths_fallback_to_mtlsclient(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default RM product paths reuse the existing mtlsclient files when no CN-named files exist."""
+    (tmp_path / "public").mkdir()
+    (tmp_path / "private").mkdir()
+    cert_path = tmp_path / "public" / "mtlsclient.pem"
+    key_path = tmp_path / "private" / "mtlsclient.key"
+    cert_path.write_text("cert", encoding="utf-8")
+    key_path.write_text("key", encoding="utf-8")
+    monkeypatch.setattr(config, "RMAPI_PERSISTENT_FOLDER", tmp_path)
+    monkeypatch.setattr(config, "read_product_certcn", lambda: "tak.localmaeher.dev.pvarki.fi")
+    assert config.default_rm_product_cert_path() == cert_path
+    assert config.default_rm_product_key_path() == key_path
+
+
+def test_rm_product_ssl_context_requires_ca_directory(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Sync TLS setup fails closed when the local CA directory is unavailable."""
+    cert_path = tmp_path / "mtlsclient.pem"
+    key_path = tmp_path / "mtlsclient.key"
+    cert_path.write_text(
+        "-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----\n",
+        encoding="utf-8",
+    )
+    key_path.write_text(
+        "-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(config, "RM_PRODUCT_CERT_PATH", cert_path)
+    monkeypatch.setattr(config, "RM_PRODUCT_KEY_PATH", key_path)
+
+    original_is_dir = Path.is_dir
+
+    def fake_is_dir(path: Path) -> bool:
+        if path == Path("/ca_public"):
+            return False
+        return original_is_dir(path)
+
+    monkeypatch.setattr(stream_sync_module.Path, "is_dir", fake_is_dir)
+
+    with pytest.raises(FileNotFoundError, match="RM product CA directory not found"):
+        MediaMTXTakSync().rm_product_ssl_context()
+
+
+@pytest.mark.asyncio
+async def test_run_once_executes_tak_mutations() -> None:
+    """One sync pass creates missing TAK video connections."""
+
+    class FakeRestHelper:
+        def __init__(self) -> None:
+            self.created: list[dict[str, Any]] = []
+            self.updated: list[tuple[str, dict[str, Any]]] = []
+            self.deleted: list[str] = []
+
+        async def tak_api_video_list(self) -> dict[str, Any]:
+            return {"success": True, "data": {"videoConnections": []}}
+
+        async def tak_api_video_create(self, payload: dict[str, Any]) -> dict[str, Any]:
+            self.created.append(payload)
+            return {"success": True, "data": {}}
+
+        async def tak_api_video_update(self, uid: str, payload: dict[str, Any]) -> dict[str, Any]:
+            self.updated.append((uid, payload))
+            return {"success": True, "data": {}}
+
+        async def tak_api_video_delete(self, uid: str) -> dict[str, Any]:
+            self.deleted.append(uid)
+            return {"success": True, "data": {}}
+
+    class FakeSync(MediaMTXTakSync):
+        async def ensure_interop(self) -> None:
+            return None
+
+        async def fetch_authz(self) -> dict[str, Any]:
+            return {"type": "basic", "username": "tak.localmaeher.dev.pvarki.fi", "password": "secret"}
+
+        async def fetch_streams(self, authz: dict[str, Any]) -> list[dict[str, Any]]:
+            assert authz["username"] == "tak.localmaeher.dev.pvarki.fi"
+            return [
+                {
+                    "path": "/live/demo",
+                    "alias": "live/demo",
+                    "urls": {"rtmps": "rtmps://streams.example.test:1936/live/demo?user=user&pass=pass"},
+                }
+            ]
+
+    rest_helper = FakeRestHelper()
+    syncer = FakeSync(rest_helper=rest_helper)  # type: ignore[arg-type]
+    plan = await syncer.run_once()
+    assert len(plan.create) == 1
+    assert rest_helper.created == [{"videoConnections": plan.create}]
+    assert rest_helper.updated == []
+    assert rest_helper.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_run_once_raises_on_create_failure() -> None:
+    """Sync fails loudly when TAK create fails."""
+
+    class FakeRestHelper:
+        async def tak_api_video_list(self) -> dict[str, Any]:
+            return {"success": True, "data": {"videoConnections": []}}
+
+        async def tak_api_video_create(self, payload: dict[str, Any]) -> dict[str, Any]:
+            _ = payload
+            return {"success": False, "data": {"error": "boom"}}
+
+        async def tak_api_video_update(self, uid: str, payload: dict[str, Any]) -> dict[str, Any]:
+            _ = uid
+            _ = payload
+            raise AssertionError("unexpected update")
+
+        async def tak_api_video_delete(self, uid: str) -> dict[str, Any]:
+            _ = uid
+            raise AssertionError("unexpected delete")
+
+    class FakeSync(MediaMTXTakSync):
+        async def ensure_interop(self) -> None:
+            return None
+
+        async def fetch_authz(self) -> dict[str, Any]:
+            return {"type": "basic", "username": "tak.localmaeher.dev.pvarki.fi", "password": "secret"}
+
+        async def fetch_streams(self, authz: dict[str, Any]) -> list[dict[str, Any]]:
+            assert authz["username"] == "tak.localmaeher.dev.pvarki.fi"
+            return [
+                {
+                    "path": "/live/demo",
+                    "alias": "live/demo",
+                    "urls": {"rtmps": "rtmps://streams.example.test:1936/live/demo?user=user&pass=pass"},
+                }
+            ]
+
+    with pytest.raises(StreamSyncError, match="Unable to create TAK video connections"):
+        await FakeSync(rest_helper=FakeRestHelper()).run_once()  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_tak_video_rest_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """TAK video helpers hit the documented endpoints and payload shapes."""
+
+    class FakeResponse:
+        def __init__(self, status: int, payload: dict[str, Any] | None = None) -> None:
+            self.status = status
+            self._payload = payload or {}
+
+        async def json(self, content_type: str | None = None) -> dict[str, Any]:
+            _ = content_type
+            return self._payload
+
+        async def text(self) -> str:
+            return ""
+
+    class FakeSession:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, str, dict[str, Any] | None]] = []
+
+        async def __aenter__(self) -> "FakeSession":
+            return self
+
+        async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+            _ = exc_type
+            _ = exc
+            _ = tb
+
+        async def get(self, url: str, ssl: ssl.SSLContext | None = None) -> FakeResponse:
+            _ = ssl
+            self.calls.append(("get", url, None))
+            return FakeResponse(200, {"videoConnections": []})
+
+        async def post(self, url: str, json: dict[str, Any], ssl: ssl.SSLContext | None = None) -> FakeResponse:
+            _ = ssl
+            self.calls.append(("post", url, json))
+            return FakeResponse(201, {})
+
+        async def put(self, url: str, json: dict[str, Any], ssl: ssl.SSLContext | None = None) -> FakeResponse:
+            _ = ssl
+            self.calls.append(("put", url, json))
+            return FakeResponse(200, {})
+
+        async def delete(self, url: str, ssl: ssl.SSLContext | None = None) -> FakeResponse:
+            _ = ssl
+            self.calls.append(("delete", url, None))
+            return FakeResponse(200, {})
+
+    helper = RestHelpers()
+    session = FakeSession()
+
+    async def fake_tak_mtls_client() -> FakeSession:
+        return session
+
+    async def fake_tak_mtls_client_sslcontext() -> None:
+        return None
+
+    monkeypatch.setattr(helper.helpers, "tak_mtls_client", fake_tak_mtls_client)
+    monkeypatch.setattr(helper.helpers, "tak_mtls_client_sslcontext", fake_tak_mtls_client_sslcontext)
+    monkeypatch.setattr(helper.helpers, "tak_base_url", lambda: "https://tak.example.test:8443")
+
+    create_payload = {"videoConnections": [{"uuid": "demo"}]}
+    update_payload = {"uuid": "demo", "feeds": []}
+    list_resp = await helper.tak_api_video_list()
+    create_resp = await helper.tak_api_video_create(create_payload)
+    update_resp = await helper.tak_api_video_update("demo", update_payload)
+    delete_resp = await helper.tak_api_video_delete("demo")
+
+    assert list_resp["success"] is True
+    assert create_resp["success"] is True
+    assert update_resp["success"] is True
+    assert delete_resp["success"] is True
+    assert session.calls == [
+        ("get", "https://tak.example.test:8443/Marti/api/video", None),
+        ("post", "https://tak.example.test:8443/Marti/api/video", create_payload),
+        ("put", "https://tak.example.test:8443/Marti/api/video/demo", update_payload),
+        ("delete", "https://tak.example.test:8443/Marti/api/video/demo", None),
+    ]

--- a/tests/test_takrmapi.py
+++ b/tests/test_takrmapi.py
@@ -20,7 +20,7 @@ from takrmapi.takutils.tak_pkg_helpers import TAKDataPackage
 
 def test_version() -> None:
     """Make sure version matches expected"""
-    assert __version__ == "1.12.1"
+    assert __version__ == "1.12.2"
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
User-facing summary
   - Added automatic MediaMTX-to-TAK stream synchronization
   - Added RTMPS-only TAK video connection mapping for active streams

  Why It's Good for the Product (Release Goal)
   - Makes live MediaMTX streams automatically available in TAK without manual setup
   - Keeps TAK stream inventory aligned with active stream state

  Any Other You'd Like to Mention
   - Includes create/update/delete synchronization against TAK Server video connections